### PR TITLE
Updated Name field regex to allow hyphen and apostrophe

### DIFF
--- a/CheckYourEligibility-Admin/Attributes/NameAttribute.cs
+++ b/CheckYourEligibility-Admin/Attributes/NameAttribute.cs
@@ -8,7 +8,7 @@ namespace CheckYourEligibility_FrontEnd.Attributes
 {
     public class NameAttribute : ValidationAttribute
     {
-        private static readonly string UnicodeOnlyPattern = @"^\p{L}+$";
+        private static readonly string UnicodeOnlyPattern = @"^[\p{L}\-']+$";
 
         private static readonly Regex regex = new Regex(UnicodeOnlyPattern);
 

--- a/CheckYourEligibility-Parent/Attributes/NameAttribute.cs
+++ b/CheckYourEligibility-Parent/Attributes/NameAttribute.cs
@@ -8,7 +8,7 @@ namespace CheckYourEligibility_FrontEnd.Attributes
 {
     public class NameAttribute : ValidationAttribute
     {
-        private static readonly string UnicodeOnlyPattern = @"^\p{L}+$";
+        private static readonly string UnicodeOnlyPattern = @"^[\p{L}\-']+$";
 
         private static readonly Regex regex = new Regex(UnicodeOnlyPattern);
 


### PR DESCRIPTION
Just a quick update to the regex for first name and last name. School is mentioned in the ticket but currently the system won't store any input outside of a selection from the list so it doesn't appear to need a code change at present.