### PR TITLE
Parent Journey - NASS page bug fix

### DIFF
--- a/CheckYourEligibility-Parent/Controllers/CheckController.cs
+++ b/CheckYourEligibility-Parent/Controllers/CheckController.cs
@@ -146,7 +146,7 @@ namespace CheckYourEligibility_FrontEnd.Controllers
                     {
                         LastName = request.LastName,
                         NationalAsylumSeekerServiceNumber = request.NationalAsylumSeekerServiceNumber,
-                        DateOfBirth = new DateOnly(request.Year.Value, request.Month.Value, request.Day.Value).ToString("dd/MM/yyyy")
+                        DateOfBirth = new DateOnly(request.Year.Value, request.Month.Value, request.Day.Value).ToString("yyyy-MM-dd")
                     }
                 };
 


### PR DESCRIPTION
The date of birth format as required for the api soft check was incorrect on the NASS journey, updated this to the required format