### PR TITLE
Store API Soft Check Response in TempData for Nass route

### DIFF
--- a/CheckYourEligibility-Parent/Controllers/CheckController.cs
+++ b/CheckYourEligibility-Parent/Controllers/CheckController.cs
@@ -154,6 +154,10 @@ namespace CheckYourEligibility_FrontEnd.Controllers
 
                 // queue api soft-check
                 var response = await _service.PostCheck(checkEligibilityRequest);
+                TempData["Response"] = JsonConvert.SerializeObject(response, Formatting.Indented, new JsonSerializerSettings()
+                {
+                    ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+                });
 
                 _logger.LogInformation($"Check processed:- {response.Data.Status} {response.Links.Get_EligibilityCheck}");
 


### PR DESCRIPTION
The outcome page after the loader screen needs to read the api response from tempdata...

This was not correctly set up for the nass route, as it was for the nino route. 

This PR addresses that problem.