### PR TITLE
Can go back to NASS page after submitting data

### DIFF
--- a/CheckYourEligibility-Parent/Controllers/CheckController.cs
+++ b/CheckYourEligibility-Parent/Controllers/CheckController.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Authentication;
 using GovUk.OneLogin.AspNetCore;
 using CheckYourEligibility_FrontEnd.Models;
 using CheckYourEligibility.Domain.Responses;
-using Azure.Core;
 
 namespace CheckYourEligibility_FrontEnd.Controllers
 {


### PR DESCRIPTION
To prevent the form resubmitting after reloading the page after submitting the form i've used the Post/Redirect/Get pattern within the NASS controller methods

User can now go back to the NASS/ASRN entry page after submitting a check, just as they can when they enter a NINO.