### PR TITLE
No NI or NASS number now directs to the "could not check" page

### DIFF
--- a/CheckYourEligibility-Parent.Tests/Attributes/NassAttributeTests.cs
+++ b/CheckYourEligibility-Parent.Tests/Attributes/NassAttributeTests.cs
@@ -19,7 +19,8 @@ namespace CheckYourEligibility_Parent.Tests.Attributes
         {
             _parent = new Parent()
             {
-                IsNassSelected = true,
+                IsNassNotSelected = false,
+                IsNinoNotSelected = true,
             };
             _nassAttribute = new TestableNassAttribute();
             _validationContext = new ValidationContext(_parent);

--- a/CheckYourEligibility-Parent.Tests/Controllers/CheckControllerTests.cs
+++ b/CheckYourEligibility-Parent.Tests/Controllers/CheckControllerTests.cs
@@ -82,8 +82,8 @@ namespace CheckYourEligibility_Parent.Tests.Controllers
                     Year = 1990,
                     NationalInsuranceNumber = "AB123456C",
                     NationalAsylumSeekerServiceNumber = null,
-                    IsNinoNotSelected = true,
-                    IsNassNotSelected = null
+                    IsNinoNotSelected = false,
+                    IsNassNotSelected = null,
                 };
 
                 _children = new Children()

--- a/CheckYourEligibility-Parent.Tests/Controllers/CheckControllerTests.cs
+++ b/CheckYourEligibility-Parent.Tests/Controllers/CheckControllerTests.cs
@@ -82,7 +82,8 @@ namespace CheckYourEligibility_Parent.Tests.Controllers
                     Year = 1990,
                     NationalInsuranceNumber = "AB123456C",
                     NationalAsylumSeekerServiceNumber = null,
-                    IsNassSelected = false
+                    IsNinoNotSelected = true,
+                    IsNassNotSelected = null
                 };
 
                 _children = new Children()
@@ -366,7 +367,7 @@ namespace CheckYourEligibility_Parent.Tests.Controllers
         public async Task Given_Nass_When_ValidDataProvided_Should_RedirectToNass()
         {
             // Arrange
-            _parent.IsNassSelected = true;
+            _parent.IsNinoNotSelected = true;
             _parent.NationalInsuranceNumber = null;
             _parent.NationalAsylumSeekerServiceNumber = "202405001";
 
@@ -656,7 +657,7 @@ namespace CheckYourEligibility_Parent.Tests.Controllers
         public async Task Given_EnterDetails_When_UserHasSelectedToInputANass_Should_RedirectToNassPage()
         {
             // Arrange
-            _parent.IsNassSelected = true;
+            _parent.IsNinoNotSelected = true;
             _parent.NationalInsuranceNumber = null;
 
             // Act

--- a/CheckYourEligibility-Parent.Tests/Models/ParentModelTests.cs
+++ b/CheckYourEligibility-Parent.Tests/Models/ParentModelTests.cs
@@ -18,17 +18,18 @@ namespace CheckYourEligibility_Parent.Tests.ViewModels
             _validationResults = new List<ValidationResult>();
         }
 
-        [TestCase(null, null, true, null, null, null, null, null, 6)]
-        [TestCase(null, null, false, null, null, null, null, null, 6)]
-        [TestCase("AB123456C", null, false, "Homer", "Simpson", 32, 01, 1990, 2)]
-        [TestCase("AB123456C", null, false, "Homer", "Simpson", 31, 13, 1990, 2)]
-        [TestCase("GB123456A", null, false, "Homer", "Simpson", 32, 13, 1990, 4)]
-        public void Given_InvalidParentModel_When_Validated_Should_ReturnExpectedNumberOfErrors(string? nino, string? nass, bool isNassSelected, string? firstName, string? lastName, int? day, int? month, int? year, int numberOfErrors)
+        [TestCase(null, null, true, false, null, null, null, null, null, 6)]
+        [TestCase(null, null, false, true, null, null, null, null, null, 6)]
+        [TestCase("AB123456C", null, false, null, "Homer", "Simpson", 32, 01, 1990, 2)]
+        [TestCase("AB123456C", null, false, null, "Homer", "Simpson", 31, 13, 1990, 2)]
+        [TestCase("GB123456A", null, false, null, "Homer", "Simpson", 32, 13, 1990, 4)]
+        public void Given_InvalidParentModel_When_Validated_Should_ReturnExpectedNumberOfErrors(string? nino, string? nass, bool? isNinoNotSelected, bool? isNassNotSelected , string? firstName, string? lastName, int? day, int? month, int? year, int numberOfErrors)
         {
             // Arrange
             _parent.NationalInsuranceNumber = nino;
             _parent.NationalAsylumSeekerServiceNumber = nass;
-            _parent.IsNassSelected = isNassSelected;
+            _parent.IsNinoNotSelected = isNinoNotSelected;
+            _parent.IsNassNotSelected = isNassNotSelected;
             _parent.FirstName = firstName;
             _parent.LastName = lastName;
             _parent.Day = day;

--- a/CheckYourEligibility-Parent/Attributes/NassAttribute.cs
+++ b/CheckYourEligibility-Parent/Attributes/NassAttribute.cs
@@ -13,7 +13,7 @@ namespace CheckYourEligibility_FrontEnd.Attributes
         {
             var model = (Parent)validationContext.ObjectInstance;
 
-            if (model.IsNassSelected == true)
+            if (model.IsNassNotSelected == true)
             {
                 if (value == null || value == "")
                 {

--- a/CheckYourEligibility-Parent/Attributes/NassAttribute.cs
+++ b/CheckYourEligibility-Parent/Attributes/NassAttribute.cs
@@ -13,7 +13,7 @@ namespace CheckYourEligibility_FrontEnd.Attributes
         {
             var model = (Parent)validationContext.ObjectInstance;
 
-            if (model.IsNassNotSelected == true)
+            if (model.IsNassNotSelected == false)
             {
                 if (value == null || value == "")
                 {

--- a/CheckYourEligibility-Parent/Attributes/NinoAttribute.cs
+++ b/CheckYourEligibility-Parent/Attributes/NinoAttribute.cs
@@ -20,7 +20,7 @@ namespace CheckYourEligibility_FrontEnd.Attributes
         {
             var model = (Parent)validationContext.ObjectInstance;
 
-            if (model.IsNassSelected == true)
+            if (model.IsNinoNotSelected == true)
             {
                 return ValidationResult.Success;
             }

--- a/CheckYourEligibility-Parent/Controllers/CheckController.cs
+++ b/CheckYourEligibility-Parent/Controllers/CheckController.cs
@@ -59,7 +59,7 @@ namespace CheckYourEligibility_FrontEnd.Controllers
         public async Task<IActionResult> Enter_Details(Parent request)
         {
             // dont want to validate nass on this page 
-            if (request.IsNassSelected == true)
+            if (request.IsNinoNotSelected == true)
             {
                 ModelState.Remove("NationalInsuranceNumber");
                 if (!request.NASSRedirect)
@@ -87,6 +87,10 @@ namespace CheckYourEligibility_FrontEnd.Controllers
                 {
                     return View("Nass");
                 }
+                else if (request.IsNassNotSelected == true )
+                {
+                    return View("Outcome/Could_Not_Check");
+                }
                 return RedirectToAction("Enter_Details");
             }
 
@@ -108,7 +112,7 @@ namespace CheckYourEligibility_FrontEnd.Controllers
             HttpContext.Session.SetString("ParentDOB", checkEligibilityRequest.Data.DateOfBirth);
 
             // if user selected to input nass, save incomplete-model to tempdata and redirect to nass page
-            if (request.IsNassSelected == true && !request.NASSRedirect)
+            if (request.IsNinoNotSelected == true && !request.NASSRedirect)
             {
                 request.NASSRedirect = true;
                 TempData["ParentDetails"] = JsonConvert.SerializeObject(request);
@@ -124,6 +128,7 @@ namespace CheckYourEligibility_FrontEnd.Controllers
             {
                 HttpContext.Session.SetString("ParentNASS", request.NationalAsylumSeekerServiceNumber);
             }
+            
             // queue api soft-check
             var response = await _checkService.PostCheck(checkEligibilityRequest);
             TempData["Response"] = JsonConvert.SerializeObject(response, Formatting.Indented, new JsonSerializerSettings()

--- a/CheckYourEligibility-Parent/Models/Parent.cs
+++ b/CheckYourEligibility-Parent/Models/Parent.cs
@@ -13,7 +13,9 @@ namespace CheckYourEligibility_FrontEnd.Models
         [MaxLength(10)]
         public string? NationalAsylumSeekerServiceNumber { get; set; }
 
-        public bool IsNassSelected { get; set; }
+        public bool? IsNassNotSelected { get; set; }
+
+        public bool? IsNinoNotSelected { get; set; }
 
         [Name]
         [Required(ErrorMessage = "First Name is required")]

--- a/CheckYourEligibility-Parent/Views/Check/Enter_Details.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Enter_Details.cshtml
@@ -104,7 +104,7 @@
 
             <div class="govuk-radios" data-module="govuk-radios">
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" asp-for="IsNassSelected" type="radio" value="false" aria-controls="conditional-ni-number" aria-expanded="false" aria-label="Yes">
+                    <input class="govuk-radios__input" asp-for="IsNinoNotSelected" type="radio" value="false" aria-controls="conditional-ni-number" aria-expanded="false" aria-label="Yes">
                     <label class="govuk-label govuk-radios__label" for="ni-number">
                         Yes
                     </label>
@@ -126,7 +126,7 @@
                     </div>
                 </div>
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" asp-for="IsNassSelected" type="radio" value="true" aria-label="No, I do not have one">
+                    <input class="govuk-radios__input" asp-for="IsNinoNotSelected" type="radio" value="true" aria-label="No, I do not have one">
                     <label class="govuk-label govuk-radios__label" for="ni-number-2">
                         No, I do not have one
                     </label>

--- a/CheckYourEligibility-Parent/Views/Check/Nass.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Nass.cshtml
@@ -42,7 +42,7 @@
 
                     <div class="govuk-radios" data-module="govuk-radios">
                         <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" asp-for="IsNassSelected" type="radio" value="true" data-aria-controls="conditional-nass-number" aria-expanded="false">
+                            <input class="govuk-radios__input" asp-for="IsNassNotSelected" type="radio" value="false" data-aria-controls="conditional-nass-number" aria-expanded="false">
                             <label class="govuk-label govuk-radios__label" for="nass-number">
                                 Yes
                             </label>
@@ -64,7 +64,7 @@
                         </div>
 
                         <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" asp-for="IsNassSelected" type="radio" value="false">
+                            <input class="govuk-radios__input" asp-for="IsNassNotSelected" type="radio" value="true">
                             <label class="govuk-label govuk-radios__label" for="nass-number-2">
                                 No, I do not have one
                             </label>


### PR DESCRIPTION
Following the parent journey without an NI number or Nass number now redirects to the appropriate "could not check" page