### PR TITLE
Change Child Date of Birth to parent Date of Birth

### DIFF
--- a/CheckYourEligibility-Admin/Controllers/ApplicationController.cs
+++ b/CheckYourEligibility-Admin/Controllers/ApplicationController.cs
@@ -416,7 +416,7 @@ namespace CheckYourEligibility_FrontEnd.Controllers
                 Status = response.Data.Status,
                 ChildName = $"{response.Data.ChildFirstName} {response.Data.ChildLastName}",
             };
-            viewData.ParentDob = DateTime.ParseExact(response.Data.ChildDateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture).ToString("dd MMMM yyyy");
+            viewData.ParentDob = DateTime.ParseExact(response.Data.ParentDateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture).ToString("dd MMMM yyyy");
             viewData.ChildDob = DateTime.ParseExact(response.Data.ChildDateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture).ToString("dd MMMM yyyy");
            
             return viewData;


### PR DESCRIPTION
On Application Detail pages the Parent Date of birth should now be properly presented. Can write a check in cypress. A follow-up to this could be including a check within Cypress for the details of the application shown on the page to ensure something like this doesn't occur again.