### PR TITLE
Jcb review page widths 190566

### DIFF
--- a/CheckYourEligibility-Admin/Views/Application/AppealsApplications.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/AppealsApplications.cshtml
@@ -1,90 +1,90 @@
 ﻿@using CheckYourEligibility_FrontEnd.ViewModels
 @model PeopleSelectionViewModel;
 
+@{
+    ViewData["Layout"] = "full";
+}
+
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>
 @* <a class="govuk-back-link-nolink"></a> *@
 
+<div class="moj-page-header-actions">
+
+    <div class="moj-page-header-actions__title">
+        <h1 class="govuk-heading-l">Process appeals (@ViewBag.TotalRecords)</h1>
+    </div>
+</div>
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body">All the children in the table on this page need to have their supporting evidence reviewed by the local authority, to see if they can get free school meals.</p>
+        </div>
+    </div>
+</div>
+
+<div class="govuk-!-padding-bottom-3"></div>
+
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h2 class="govuk-heading-m">How to process appeals</h2>
+            <ol class="govuk-list govuk-list--number">
+                <li>For each record with the status 'Evidence needed', ask the parent or guardian for supporting evidence. @Html.ActionLink("See a full list of acceptable documents.", "EvidenceGuidance", "application", null, new { @class = "govuk-link" })</li>
+                <li>Once you have this, go into the record by selecting the reference number, and follow the instructions there.</li>
+            </ol>
+        </div>
+    </div>
+</div>
+<div class="govuk-!-padding-bottom-3"></div>
+
 <div class="govuk-grid-row">
+
     <div class="govuk-grid-column-full">
-        <div class="moj-page-header-actions">
+        @if (Model.People != null && Model.People.Any())
+        {
+            <table class="govuk-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th class="govuk-table__header" scope="col" id="select-all"></th>
+                        <th class="govuk-table__header" scope="col">Reference</th>
+                        <th class="govuk-table__header" scope="col">Parent / Guardian</th>
+                        <th class="govuk-table__header" scope="col">Child</th>
+                        <th class="govuk-table__header" scope="col">Child date of birth</th>
+                        <th class="govuk-table__header" scope="col"> Status</th>
+                        <th class="govuk-table__header" scope="col">Submission date</th>
+                    </tr>
+                </thead>
+                @Html.EditorFor(model => model.People)
+            </table>
 
-            <div class="moj-page-header-actions__title">
-                <h1 class="govuk-heading-l">Process appeals (@ViewBag.TotalRecords)</h1>
-            </div>
-        </div>
-        <div class="govuk-width-container">
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
-                    <p class="govuk-body">All the children in the table on this page need to have their supporting evidence reviewed by the local authority, to see if they can get free school meals.</p>
-                </div>
-            </div>
-        </div>
+            <nav class="govuk-pagination" role="navigation" aria-label="results navigation">
+                <ul class="govuk-pagination__list">
+                    @if (ViewBag.CurrentPage > 1)
+                    {
+                        <li class="govuk-pagination__item">
+                            <a class="govuk-link govuk-pagination__link" href="@Url.Action("AppealsApplications", new { PageNumber = ViewBag.CurrentPage - 1 })">Previous</a>
+                        </li>
+                    }
 
-        <div class="govuk-!-padding-bottom-3"></div>
+                    @for (int i = 1; i <= ViewBag.TotalPages; i++)
+                    {
+                        <li class="govuk-pagination__item @(ViewBag.CurrentPage == i ? "govuk-pagination__item--current" : "")">
+                            <a class="govuk-link govuk-pagination__link" href="@Url.Action("AppealsApplications", new { PageNumber = i })">@i</a>
+                        </li>
+                    }
 
-        <div class="govuk-width-container">
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
-                    <h2 class="govuk-heading-m">How to process appeals</h2>
-                    <ol class="govuk-list govuk-list--number">
-                        <li>For each record with the status 'Evidence needed', ask the parent or guardian for supporting evidence. @Html.ActionLink("See a full list of acceptable documents.", "EvidenceGuidance", "application", null, new { @class = "govuk-link" })</li>
-                        <li>Once you have this, go into the record by selecting the reference number, and follow the instructions there.</li>
-                    </ol>
-                </div>
-            </div>
-        </div>
-        <div class="govuk-!-padding-bottom-3"></div>
-
-        <div class="govuk-grid-row">
-
-            <div class="govuk-grid-column-full">
-                @if (Model.People != null && Model.People.Any())
-                {
-                <table class="govuk-table">
-                    <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                            <th class="govuk-table__header" scope="col" id="select-all"></th>
-                            <th class="govuk-table__header" scope="col">Reference</th>
-                            <th class="govuk-table__header" scope="col">Parent / Guardian</th>
-                            <th class="govuk-table__header" scope="col">Child</th>
-                            <th class="govuk-table__header" scope="col">Child date of birth</th>
-                            <th class="govuk-table__header" scope="col"> Status</th>
-                            <th class="govuk-table__header" scope="col">Submission date</th>
-                        </tr>
-                    </thead>
-                    @Html.EditorFor(model => model.People)
-                </table>
-
-                <nav class="govuk-pagination" role="navigation" aria-label="results navigation">
-                    <ul class="govuk-pagination__list">
-                        @if (ViewBag.CurrentPage > 1)
-                        {
-                            <li class="govuk-pagination__item">
-                                    <a class="govuk-link govuk-pagination__link" href="@Url.Action("AppealsApplications", new { PageNumber = ViewBag.CurrentPage - 1 })">Previous</a>
-                            </li>
-                        }
-
-                        @for (int i = 1; i <= ViewBag.TotalPages; i++)
-                        {
-                            <li class="govuk-pagination__item @(ViewBag.CurrentPage == i ? "govuk-pagination__item--current" : "")">
-                                    <a class="govuk-link govuk-pagination__link" href="@Url.Action("AppealsApplications", new { PageNumber = i })">@i</a>
-                            </li>
-                        }
-
-                        @if (ViewBag.CurrentPage < ViewBag.TotalPages)
-                        {
-                            <li class="govuk-pagination__item">
-                                    <a class="govuk-link govuk-pagination__link" href="@Url.Action("AppealsApplications", new { PageNumber = ViewBag.CurrentPage + 1 })">Next</a>
-                            </li>
-                        }
-                    </ul>
-                </nav>
-                }
-                else
-                {
-                <p>No results found.</p>
-                }
-            </div>
-        </div>
+                    @if (ViewBag.CurrentPage < ViewBag.TotalPages)
+                    {
+                        <li class="govuk-pagination__item">
+                            <a class="govuk-link govuk-pagination__link" href="@Url.Action("AppealsApplications", new { PageNumber = ViewBag.CurrentPage + 1 })">Next</a>
+                        </li>
+                    }
+                </ul>
+            </nav>
+        }
+        else
+        {
+            <p>No results found.</p>
+        }
     </div>
 </div>

--- a/CheckYourEligibility-Admin/Views/Application/ApplicationDetail.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/ApplicationDetail.cshtml
@@ -1,38 +1,34 @@
 ﻿@using CheckYourEligibility_FrontEnd.ViewModels
 @model ApplicationDetailViewModel
 
+@{
+    ViewData["Layout"] = "full";
+}
+
 <a class="govuk-back-link" href="@Url.Action("SearchResults", "Application")" onclick="history.back(); return false;">Back</a>
 @* <a class="govuk-back-link-nolink"></a> *@
 
-<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row govuk-!-margin-bottom-5">
-        <div class="govuk-grid-column-full">
+<div class="moj-page-header-actions">
 
-            <div class="moj-page-header-actions">
-
-                <div class="moj-page-header-actions__title">
-                    <h1 class="govuk-heading-xl">@Model.ParentName</h1>
-                </div>
-                <div class="moj-page-header-actions__actions">
-                    <div class="moj-button-menu">
-                        <div class="moj-button-menu__wrapper"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="govuk-width-container">
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-full">
-                        <p class="govuk-heading-s">Once you've received evidence from this parent or guardian:</p>
-                        <ol class="govuk-list govuk-list--number">
-                            <li>Send it to your local authority contact along with the application reference number. Typically this would happen via email.</li>
-                            <li>Select ‘Send for review’ on this page. This will notify the local authority that the free school meals application is ready for their attention.</li>
-                        </ol>
-                    </div>
-                </div>
-            </div>
+    <div class="moj-page-header-actions__title">
+        <h1 class="govuk-heading-xl">@Model.ParentName</h1>
+    </div>
+    <div class="moj-page-header-actions__actions">
+        <div class="moj-button-menu">
+            <div class="moj-button-menu__wrapper"></div>
         </div>
     </div>
-    @Html.Partial("ApplicationDetailPartial", Model)
+</div>
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-heading-s">Once you've received evidence from this parent or guardian:</p>
+            <ol class="govuk-list govuk-list--number">
+                <li>Send it to your local authority contact along with the application reference number. Typically this would happen via email.</li>
+                <li>Select ‘Send for review’ on this page. This will notify the local authority that the free school meals application is ready for their attention.</li>
+            </ol>
+        </div>
+    </div>
+</div>
 
-</main>
-
+@Html.Partial("ApplicationDetailPartial", Model)

--- a/CheckYourEligibility-Admin/Views/Application/ApplicationDetailAppeal.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/ApplicationDetailAppeal.cshtml
@@ -1,43 +1,36 @@
 ﻿@using CheckYourEligibility_FrontEnd.ViewModels
 @model ApplicationDetailViewModel
 
+@{
+    ViewData["Layout"] = "full";
+}
+
 <a class="govuk-back-link" href="@Url.Action("AppealsApplications", "Application")" onclick="history.back(); return false;">Back</a>
 @* <a class="govuk-back-link-nolink"></a> *@
 
-<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row govuk-!-margin-bottom-5">
-        <div class="govuk-grid-column-full">
-            <div class="moj-page-header-actions">
+<div class="moj-page-header-actions">
 
-                <div class="moj-page-header-actions__title">
-                    <h1 class="govuk-heading-xl">@Model.ParentName</h1>
-                </div>
-
-
-                <div class="moj-page-header-actions__actions">
-                   <div class="moj-button-menu">
-                        <div class="moj-button-menu__wrapper"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="govuk-width-container">
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-full">
-                        <p class="govuk-heading-s">Once you've received evidence from this parent or guardian:</p>
-                        <ol class="govuk-list govuk-list--number">
-                            <li>Send it to your local authority contact along with the application reference number. Typically this would happen via email.</li>
-                            <li>Select ‘Send for review’ on this page. This will notify the local authority that the free school meals application is ready for their attention.</li>
-                        </ol>
-                    </div>
-                </div>
-            </div>
-
-
-        </div>
-
+    <div class="moj-page-header-actions__title">
+        <h1 class="govuk-heading-xl">@Model.ParentName</h1>
     </div>
 
-    @Html.Partial("ApplicationDetailPartial", Model)
- 
-</main>
 
+    <div class="moj-page-header-actions__actions">
+        <div class="moj-button-menu">
+            <div class="moj-button-menu__wrapper"></div>
+        </div>
+    </div>
+</div>
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-heading-s">Once you've received evidence from this parent or guardian:</p>
+            <ol class="govuk-list govuk-list--number">
+                <li>Send it to your local authority contact along with the application reference number. Typically this would happen via email.</li>
+                <li>Select ‘Send for review’ on this page. This will notify the local authority that the free school meals application is ready for their attention.</li>
+            </ol>
+        </div>
+    </div>
+</div>
+
+@Html.Partial("ApplicationDetailPartial", Model)

--- a/CheckYourEligibility-Admin/Views/Application/ApplicationDetailAppealConfirmation.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/ApplicationDetailAppealConfirmation.cshtml
@@ -1,24 +1,17 @@
 ﻿@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<main class="govuk-main-wrapper" id="main-content">
+@{
+    ViewData["Layout"] = "two_thirds";
+}
 
+<p class="govuk-heading-l">Are you sure?</p>
+<p class="govuk-body">Sending this record on to the local authority for review will also prompt them to check the evidence you send them separately. </p>
 
-    <div class="govuk-width-container">
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <p class="govuk-heading-l">Are you sure?</p>
-                <p class="govuk-body">Sending this record on to the local authority for review will also prompt them to check the evidence you send them separately. </p>
-            </div>
-        </div>
-    </div>
+<div class="govuk-!-padding-bottom-3"></div>
 
-    <div class="govuk-!-padding-bottom-3"></div>
+@Html.ActionLink("Yes, send now", "ApplicationDetailAppealSend", "application", new { id = @TempData["AppAppealID"] }, new { @class = "govuk-button govuk-button--primary" })
 
-    @Html.ActionLink("Yes, send now", "ApplicationDetailAppealSend", "application", new { id = @TempData["AppAppealID"] }, new { @class = "govuk-button govuk-button--primary" })
+@Html.ActionLink("No, return to record", "ApplicationDetailAppeal", "application", new { id = @TempData["AppAppealID"] }, new { @class = "govuk-button govuk-button--secondary" })
 
-    @Html.ActionLink("No, return to record", "ApplicationDetailAppeal", "application", new { id = @TempData["AppAppealID"] }, new { @class = "govuk-button govuk-button--secondary" })
-
-    <div class="govuk-!-padding-bottom-3"></div>
-
-</main>
+<div class="govuk-!-padding-bottom-3"></div>

--- a/CheckYourEligibility-Admin/Views/Application/ApplicationDetailAppealConfirmationSent.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/ApplicationDetailAppealConfirmationSent.cshtml
@@ -1,24 +1,21 @@
 ﻿@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-width-container">
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <span class="govuk-caption-l">Reference @ViewBag.AppReference</span>
-                <h1 class="govuk-heading-xl">Application sent for review </h1>
-                <p>
-                    Its status has now changed to ‘Sent for review’.
+@{
+    ViewData["Layout"] = "two_thirds";
+}
 
-                    If you don’t hear back from the local authority, get in touch with them to ask for an update.
-                </p>
-            </div>
-        </div>
-    </div>
-    @Html.ActionLink("Return to record", "ApplicationDetail", "application", new { id = @TempData["AppAppealID"] }, new { @class = "govuk-button govuk-button--primary" })
-    
-    <div class="govuk-!-padding-bottom-3"></div>
-    <p>@Html.ActionLink("Process more appeals", "AppealsApplications", "application", new { PageNumber = 0 }, new { @class = "" })</p>
-    <p>@Html.ActionLink("Return to dashboard", "Index", "Home", null, new { @class = "" })</p>
-    <p>@Html.ActionLink("Sign out", "SignOut", "Account", null, new { @class = "" })</p>
-</main>
+<span class="govuk-caption-l">Reference @ViewBag.AppReference</span>
+<h1 class="govuk-heading-xl">Application sent for review </h1>
+<p>
+    Its status has now changed to ‘Sent for review’.
+
+    If you don’t hear back from the local authority, get in touch with them to ask for an update.
+</p>
+
+@Html.ActionLink("Return to record", "ApplicationDetail", "application", new { id = @TempData["AppAppealID"] }, new { @class = "govuk-button govuk-button--primary" })
+
+<div class="govuk-!-padding-bottom-3"></div>
+<p>@Html.ActionLink("Process more appeals", "AppealsApplications", "application", new { PageNumber = 0 }, new { @class = "" })</p>
+<p>@Html.ActionLink("Return to dashboard", "Index", "Home", null, new { @class = "" })</p>
+<p>@Html.ActionLink("Sign out", "SignOut", "Account", null, new { @class = "" })</p>

--- a/CheckYourEligibility-Admin/Views/Application/ApplicationDetailFinalise.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/ApplicationDetailFinalise.cshtml
@@ -1,46 +1,34 @@
 ﻿@using CheckYourEligibility_FrontEnd.ViewModels
 @model ApplicationDetailViewModel
 
+@{
+    ViewData["Layout"] = "full";
+}
+
 <a class="govuk-back-link" href="@Url.Action("FinaliseApplications", "Application")" onclick="history.back(); return false;">Back</a>
 @* <a class="govuk-back-link-nolink"></a> *@
 
-<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row govuk-!-margin-bottom-5">
-        <div class="govuk-grid-column-full">
-
-
-
-
-
-            <div class="moj-page-header-actions">
-
-                <div class="moj-page-header-actions__title">
-                    <h1 class="govuk-heading-xl">@Model.ParentName</h1>
-                </div>
-                <div class="moj-page-header-actions__actions">
-
-
-                    <div class="moj-button-menu">
-                        <div class="moj-button-menu__wrapper"></div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="govuk-width-container">
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-full">
-                        <p class="govuk-heading-s">Once you've received evidence from this parent or guardian:</p>
-                        <ol class="govuk-list govuk-list--number">
-                            <li>Send it to your local authority contact along with the application reference number. Typically this would happen via email.</li>
-                            <li>Select ‘Send for review’ on this page. This will notify the local authority that the free school meals application is ready for their attention.</li>
-                        </ol>
-                    </div>
-                </div>
-            </div>
-        </div>
-
+<div class="moj-page-header-actions">
+    <div class="moj-page-header-actions__title">
+        <h1 class="govuk-heading-xl">@Model.ParentName</h1>
     </div>
+    <div class="moj-page-header-actions__actions">
+        <div class="moj-button-menu">
+            <div class="moj-button-menu__wrapper"></div>
+        </div>
+    </div>
+</div>
 
-    @Html.Partial("ApplicationDetailPartial", Model)
-</main>
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-heading-s">Once you've received evidence from this parent or guardian:</p>
+            <ol class="govuk-list govuk-list--number">
+                <li>Send it to your local authority contact along with the application reference number. Typically this would happen via email.</li>
+                <li>Select ‘Send for review’ on this page. This will notify the local authority that the free school meals application is ready for their attention.</li>
+            </ol>
+        </div>
+    </div>
+</div>
 
+@Html.Partial("ApplicationDetailPartial", Model)

--- a/CheckYourEligibility-Admin/Views/Application/ApplicationDetailLa.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/ApplicationDetailLa.cshtml
@@ -1,33 +1,26 @@
 ﻿@using CheckYourEligibility_FrontEnd.ViewModels
 @model ApplicationDetailViewModel
 
+@{
+    ViewData["Layout"] = "full";
+}
+
 <a class="govuk-back-link" href="@Url.Action("PendingApplications", "Application")" onclick="history.back(); return false;">Back</a>
 @* <a class="govuk-back-link-nolink"></a> *@
 
-<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row govuk-!-margin-bottom-5">
-        <div class="govuk-grid-column-full">
-            <div class="moj-page-header-actions whitespaceDelete">
-                <div class="moj-page-header-actions whitespaceDelete">
-                    <div class="moj-page-header-actions__title">
-                        <h1 class="govuk-heading-xl">@Model.ParentName</h1>
-                    </div>
+<div class="moj-page-header-actions">
+    <div class="moj-page-header-actions__title">
+        <h1 class="govuk-heading-xl">@Model.ParentName</h1>
+    </div>
 
-                    <div class="moj-page-header-actions__actions whitespaceDelete">
-                        <div class="moj-button-menu">
-                            <div class="moj-button-menu__wrapper">
-                                @Html.ActionLink("Approve application", "ApproveConfirmation", "application", new { id = Model.Id }, new { @class = "govuk-button govuk-button--primary moj-button-menu__item" })
-                                @Html.ActionLink("Decline application", "DeclineConfirmation", "application", new { id = Model.Id }, new { @class = "govuk-button govuk-button--secondary moj-button-menu__item" })
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
+    <div class="moj-page-header-actions__actions">
+        <div class="moj-button-menu">
+            <div class="moj-button-menu__wrapper">
+                @Html.ActionLink("Approve application", "ApproveConfirmation", "application", new { id = Model.Id }, new { @class = "govuk-button govuk-button--primary moj-button-menu__item" })
+                @Html.ActionLink("Decline application", "DeclineConfirmation", "application", new { id = Model.Id }, new { @class = "govuk-button govuk-button--secondary moj-button-menu__item" })
             </div>
         </div>
     </div>
+</div>
 
-    @Html.Partial("ApplicationDetailPartial", Model)
-
-</main>
-
+@Html.Partial("ApplicationDetailPartial", Model)

--- a/CheckYourEligibility-Admin/Views/Application/ApplicationFinaliseConfirmation.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/ApplicationFinaliseConfirmation.cshtml
@@ -1,31 +1,18 @@
-﻿@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
+﻿@{
+    ViewData["Layout"] = "two_thirds";
+}
+
+@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<div class="govuk-!-padding-bottom-3"></div>
-<main class="govuk-main-wrapper" id="main-content">
+<h1 class="govuk-heading-l">Finalise these applications?</h1>
+<div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden">Warning</span>
+        Applications should only be finalised after you've added the details to your own system.
+    </strong>
+</div>
 
-
-    <div class="govuk-width-container">
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <h1 class="govuk-heading-l">Finalise these applications?</h1>
-                <div class="govuk-warning-text">
-                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <strong class="govuk-warning-text__text">
-                        <span class="govuk-visually-hidden">Warning</span>
-                        Applications should only be finalised after you've added the details to your own system.
-                    </strong>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="govuk-!-padding-bottom-3"></div>
-
-    @Html.ActionLink("Yes, finalise now", "ApplicationFinaliseSend", "application", null, new { @class = "govuk-button govuk-button--primary" })
-
-    @Html.ActionLink("No, return to table", "FinaliseApplications", "application", null, new { @class = "govuk-button govuk-button--secondary" })
-
-    <div class="govuk-!-padding-bottom-3"></div>
-
-</main>
+@Html.ActionLink("Yes, finalise now", "ApplicationFinaliseSend", "application", null, new { @class = "govuk-button govuk-button--primary" })
+@Html.ActionLink("No, return to table", "FinaliseApplications", "application", null, new { @class = "govuk-button govuk-button--secondary" })

--- a/CheckYourEligibility-Admin/Views/Application/ApproveConfirmation.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/ApproveConfirmation.cshtml
@@ -1,32 +1,18 @@
-﻿@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
+﻿@{
+    ViewData["Layout"] = "two_thirds";
+}
+
+@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<div class="govuk-!-padding-bottom-3"></div>
-<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-width-container">
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <h1 class="govuk-heading-l">Approve this application?</h1>
-                <div class="govuk-warning-text">
-                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <strong class="govuk-warning-text__text">
-                        <span class="govuk-visually-hidden">Warning</span>
-                        The parent or guardian will have to start a new application if you make a mistake.
-                    </strong>
-                </div>
-            </div>
-        </div>
-    </div>
+<h1 class="govuk-heading-l">Approve this application?</h1>
+<div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden">Warning</span>
+        The parent or guardian will have to start a new application if you make a mistake.
+    </strong>
+</div>
 
-    <div class="govuk-!-padding-bottom-3"></div>
-
-    @Html.ActionLink("Yes, approve now", "ApplicationApproveSend", "application", new { id = @TempData["AppApproveId"]}, new { @class = "govuk-button govuk-button--primary" })
-
-    @Html.ActionLink("No, return to table", "PendingApplications", "application", new { id = @TempData["AppApproveId"]}, new { @class = "govuk-button govuk-button--secondary" })
-
-    <div class="govuk-!-padding-bottom-3"></div>
-
-</main>
-
-
-
+@Html.ActionLink("Yes, approve now", "ApplicationApproveSend", "application", new { id = @TempData["AppApproveId"] }, new { @class = "govuk-button govuk-button--primary" })
+@Html.ActionLink("No, return to table", "PendingApplications", "application", new { id = @TempData["AppApproveId"] }, new { @class = "govuk-button govuk-button--secondary" })

--- a/CheckYourEligibility-Admin/Views/Application/DeclineConfirmation.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/DeclineConfirmation.cshtml
@@ -1,29 +1,18 @@
-﻿@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
+﻿@{
+    ViewData["Layout"] = "two_thirds";
+}
+
+@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<div class="govuk-!-padding-bottom-3"></div>
-<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-width-container">
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <h1 class="govuk-heading-l">Decline this application?</h1>
-                <div class="govuk-warning-text">
-                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <strong class="govuk-warning-text__text">
-                        <span class="govuk-visually-hidden">Warning</span>
-                        The parent or guardian will have to start a new application if you make a mistake.
-                    </strong>
-                </div>
-            </div>
-        </div>
-    </div>
+<h1 class="govuk-heading-l">Decline this application?</h1>
+<div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden">Warning</span>
+        The parent or guardian will have to start a new application if you make a mistake.
+    </strong>
+</div>
 
-    <div class="govuk-!-padding-bottom-3"></div>
-
-    @Html.ActionLink("Yes, decline now", "ApplicationDeclineSend", "application", new { id = @TempData["AppApproveId"] }, new { @class = "govuk-button govuk-button--primary" })
-
-    @Html.ActionLink("No, return to table", "PendingApplications", "application", new { id = @TempData["AppApproveId"] }, new { @class = "govuk-button govuk-button--secondary" })
-
-    <div class="govuk-!-padding-bottom-3"></div>
-
-</main>
+@Html.ActionLink("Yes, decline now", "ApplicationDeclineSend", "application", new { id = @TempData["AppApproveId"] }, new { @class = "govuk-button govuk-button--primary" })
+@Html.ActionLink("No, return to table", "PendingApplications", "application", new { id = @TempData["AppApproveId"] }, new { @class = "govuk-button govuk-button--secondary" })

--- a/CheckYourEligibility-Admin/Views/Application/EvidenceGuidance.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/EvidenceGuidance.cshtml
@@ -1,49 +1,43 @@
-﻿<a class="govuk-back-link" href="@Url.Action("Application", "AppealsApplications")" onclick="history.back(); return false;">Back</a>
+﻿@{
+    ViewData["Layout"] = "two_thirds";
+}
+
+<a class="govuk-back-link" href="@Url.Action("Application", "AppealsApplications")" onclick="history.back(); return false;">Back</a>
 @* <a class="govuk-back-link-nolink"></a> *@
 
-<main class="govuk-main-wrapper" id="main-content">
-          
+<h1 class="govuk-heading-l">Guidance for collecting evidence</h1>
+<h2 class="govuk-heading-m">To support local authority review of an application for free school meals, you’ll need to ask the parent or guardian for supporting evidence. </h2>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Guidance for collecting evidence</h1>
-        <h2 class="govuk-heading-m">To support local authority review of an application for free school meals, you’ll need to ask the parent or guardian for supporting evidence. </h2>
+<p class="govuk-body">The following kinds of evidence are acceptable: </p>
+<ul class="govuk-list govuk-list--bullet">
+    <li>Universal Credit - household income must be less than £7,400 a year (after tax and not including any benefits)</li>
+    <li>Income Support</li>
+    <li>income-based Jobseeker’s Allowance</li>
+    <li>income-related Employment and Support Allowance</li>
+    <li>support under Part VI of the Immigration and Asylum Act 1999</li>
+    <li>the guaranteed element of Pension Credit</li>
+    <li>Child Tax Credit (provided the parent or guardian is not also entitled to Working Tax Credit and has an annual gross income of no more than £16,190)</li>
+    <li>Working Tax Credit run-on - paid for 4 weeks after they stop qualifying for Working Tax Credit</li>
+</ul>
 
-        <p class="govuk-body">The following kinds of evidence are acceptable: </p>
-        <ul class="govuk-list govuk-list--bullet">
-            <li>Universal Credit - household income must be less than £7,400 a year (after tax and not including any benefits)</li>
-            <li>Income Support</li>
-            <li>income-based Jobseeker’s Allowance</li>
-            <li>income-related Employment and Support Allowance</li>
-            <li>support under Part VI of the Immigration and Asylum Act 1999</li>
-            <li>the guaranteed element of Pension Credit</li>
-            <li>Child Tax Credit (provided the parent or guardian is not also entitled to Working Tax Credit and has an annual gross income of no more than £16,190)</li>
-            <li>Working Tax Credit run-on - paid for 4 weeks after they stop qualifying for Working Tax Credit</li>
-          </ul>          
+<h2 class="govuk-heading-m">Parents or guardians who wish to appeal </h2>
+<p class="govuk-body">You will need to support local authority review of parents or guardians who:  </p>
+<ul class="govuk-list govuk-list--bullet">
+    <li>are listed in the @Html.ActionLink("‘Process appeals’ (opens in a new tab)", "", "application", null, new { @class = "govuk-link ", target = "_blank" }) table with the status ‘Evidence needed’</li>
+    <li>generate the result ‘the children of this parent or guardian may not be entitled to free school meals’ when checked </li>
+</ul>
+<p class="govuk-body">A <strong>‘may not be entitled’</strong> outcome for the free school meal check does not automatically mean the children in question can’t get free school meals.</p>
+<p class="govuk-body">For any parents or guardians who wish to appeal, a review will take place. </p>
 
-        <h2 class="govuk-heading-m">Parents or guardians who wish to appeal </h2>
-        <p class="govuk-body">You will need to support local authority review of parents or guardians who:  </p>
-        <ul class="govuk-list govuk-list--bullet">
-                <li>are listed in the @Html.ActionLink("‘Process appeals’ (opens in a new tab)", "", "application", null, new { @class = "govuk-link ", target = "_blank" }) table with the status ‘Evidence needed’</li>
-            <li>generate the result ‘the children of this parent or guardian may not be entitled to free school meals’ when checked </li>
-        </ul>
-        <p class="govuk-body">A <strong>‘may not be entitled’</strong> outcome for the free school meal check does not automatically mean the children in question can’t get free school meals.</p>
-        <p class="govuk-body">For any parents or guardians who wish to appeal, a review will take place. </p>
-        
+<h2 class="govuk-heading-m">Gathering evidence </h2>
+<p class="govuk-body">To support the appeal process you'll need to: </p>
+<ol class="govuk-list govuk-list--number">
+    <li>Speak to the parent or guardian and make sure they understand that supporting evidence is needed to properly assess their application for free school meals.</li>
+    <li>Ask them to provide one of the document types listed, either as a physical or digital copy. </li>
+    <li>Once you have the evidence, send it on to the local authority. Typically this would happen by email. </li>
+    <li>Go to <a class="govuk-visually-hidden">(opens in new tab), class="govuk-link" target="_blank" href="http://localhost:3000/current/checker/process-appeals"&gt;‘Process appeals’</a> in your dashboard and follow the instructions there. </li>
+    <li>Wait to hear back from the local authority with a decision on the appeal, then pass this on to the parent or guardian.  </li>
+</ol>
 
-        <h2 class="govuk-heading-m">Gathering evidence </h2>
-        <p class="govuk-body">To support the appeal process you'll need to: </p>
-        <ol class="govuk-list govuk-list--number">
-            <li>Speak to the parent or guardian and make sure they understand that supporting evidence is needed to properly assess their application for free school meals.</li>
-              <li>Ask them to provide one of the document types listed, either as a physical or digital copy. </li>
-            <li>Once you have the evidence, send it on to the local authority. Typically this would happen by email. </li>
-            <li>Go to <a class="govuk-visually-hidden">(opens in new tab), class="govuk-link" target="_blank" href="http://localhost:3000/current/checker/process-appeals"&gt;‘Process appeals’</a> in your dashboard and follow the instructions there. </li>
-            <li>Wait to hear back from the local authority with a decision on the appeal, then pass this on to the parent or guardian.  </li>
-          </ol>  
-        
-      <h2 class="govuk-heading-m">Further guidance</h2>
-      <p class="govuk-body">If you couldn’t find what you need on this page, refer to the <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://assets.publishing.service.gov.uk/media/65fdad5965ca2f00117da947/Free_school_meals.pdf">in-depth guidance on free school meals (opens in a new tab).</a> </p>
-
-    </div> 
-
-        </div></main>
+<h2 class="govuk-heading-m">Further guidance</h2>
+<p class="govuk-body">If you couldn’t find what you need on this page, refer to the <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://assets.publishing.service.gov.uk/media/65fdad5965ca2f00117da947/Free_school_meals.pdf">in-depth guidance on free school meals (opens in a new tab).</a> </p>

--- a/CheckYourEligibility-Admin/Views/Application/FinaliseApplications.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/FinaliseApplications.cshtml
@@ -1,101 +1,85 @@
 ﻿@using CheckYourEligibility_FrontEnd.ViewModels
 @model PeopleSelectionViewModel;
 
+@{
+    ViewData["Layout"] = "full";
+}
+
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>
 @* <a class="govuk-back-link-nolink"></a> *@
 
-<main class="govuk-main-wrapper" id="main-content">
-
-
+<div class="moj-page-header-actions">
+    <div class="moj-page-header-actions__title">
+        <h1 class="govuk-heading-l">Finalise applications (@ViewBag.TotalRecords)</h1>
+    </div>
+</div>
+<div class="govuk-width-container">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-
-            <div class="moj-page-header-actions">
-
-                <div class="moj-page-header-actions__title">
-                    <h1 class="govuk-heading-l">Finalise applications (@ViewBag.TotalRecords)</h1>
-                </div>
-            </div>
-            <div class="govuk-width-container">
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-full">
-                        <p class="govuk-body">All the children in the table on this page are entitled to free school meals. Now you should finalise their applications.</p>
-                    </div>
-                </div>
-            </div>
-
-            <div class="govuk-!-padding-bottom-3"></div>
-
-
-            <h2 class="govuk-heading-m">How to finalise</h2>
-
-            <ol>
-                <li>If you haven't already, add the details of each application to your own system.</li>
-                <li>Select the records you've added using the tick boxes.</li>
-                <li>Click 'Finalise applications'.</li>
-            </ol>
-
-            <div class="govuk-!-padding-bottom-3"></div>
-
-
-            
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
-
-                    @using (Html.BeginForm("FinaliseSelectedApplications", "Application", FormMethod.Post, new { encType = "multipart/form-data", name = "myform" }))
-{
-                        <div class="moj-button-action">
-
-                            <input type="submit" name="operation" id="submit" value="Finalise applications" class="govuk-button" data-module="govuk-button" />
-                           
-                                @Html.ActionLink("Download all files", "FinalisedApplicationsdownload", "Application", null, new { @class = "govuk-button govuk-button--secondary" })
-                        </div>
-                        
-
-                    <table class="govuk-table" data-module="moj-multi-select" data-multi-select-checkbox="#select-all">
-                        <thead class="govuk-table__head">
-                            <tr class="govuk-table__row">
-                                <th class="govuk-table__header" scope="col" id="select-all"></th>
-                                <th class="govuk-table__header" scope="col">Reference</th>
-                                <th class="govuk-table__header" scope="col">Parent / Guardian</th>
-                                <th class="govuk-table__header" scope="col">Child</th>
-                                <th class="govuk-table__header" scope="col">Child date of birth</th>
-                                <th class="govuk-table__header" scope="col"> Status</th>
-                                <th class="govuk-table__header" scope="col">Submission date</th>
-                            </tr>
-                        </thead>
-                       
-                            @Html.EditorFor(model => model.People)
-                    </table>
-                        <nav class="govuk-pagination" role="navigation" aria-label="results navigation">
-                            <ul class="govuk-pagination__list">
-                                @if (ViewBag.CurrentPage > 1)
-                                {
-                                    <li class="govuk-pagination__item">
-                                        <a class="govuk-link govuk-pagination__link" href="@Url.Action("FinaliseApplications", new { PageNumber = ViewBag.CurrentPage - 1 })">Previous</a>
-                                    </li>
-                                }
-
-                                @for (int i = 1; i <= ViewBag.TotalPages; i++)
-                                {
-                                    <li class="govuk-pagination__item @(ViewBag.CurrentPage == i ? "govuk-pagination__item--current" : "")">
-                                        <a class="govuk-link govuk-pagination__link" href="@Url.Action("FinaliseApplications", new { PageNumber = i })">@i</a>
-                                    </li>
-                                }
-
-                                @if (ViewBag.CurrentPage < ViewBag.TotalPages)
-                                {
-                                    <li class="govuk-pagination__item">
-                                        <a class="govuk-link govuk-pagination__link" href="@Url.Action("FinaliseApplications", new { PageNumber = ViewBag.CurrentPage + 1 })">Next</a>
-                                    </li>
-                                }
-                            </ul>
-                        </nav>
-                    }
-                </div>
-            </div>
+            <p class="govuk-body">All the children in the table on this page are entitled to free school meals. Now you should finalise their applications.</p>
         </div>
     </div>
-</main>
+</div>
+<div class="govuk-!-padding-bottom-3"></div>
 
+<h2 class="govuk-heading-m">How to finalise</h2>
+<ol>
+    <li>If you haven't already, add the details of each application to your own system.</li>
+    <li>Select the records you've added using the tick boxes.</li>
+    <li>Click 'Finalise applications'.</li>
+</ol>
+<div class="govuk-!-padding-bottom-3"></div>
 
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        @using (Html.BeginForm("FinaliseSelectedApplications", "Application", FormMethod.Post, new { encType = "multipart/form-data", name = "myform" }))
+        {
+            <div class="moj-button-action">
+
+                <input type="submit" name="operation" id="submit" value="Finalise applications" class="govuk-button" data-module="govuk-button" />
+
+                @Html.ActionLink("Download all files", "FinalisedApplicationsdownload", "Application", null, new { @class = "govuk-button govuk-button--secondary" })
+            </div>
+
+            <table class="govuk-table" data-module="moj-multi-select" data-multi-select-checkbox="#select-all">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th class="govuk-table__header" scope="col" id="select-all"></th>
+                        <th class="govuk-table__header" scope="col">Reference</th>
+                        <th class="govuk-table__header" scope="col">Parent / Guardian</th>
+                        <th class="govuk-table__header" scope="col">Child</th>
+                        <th class="govuk-table__header" scope="col">Child date of birth</th>
+                        <th class="govuk-table__header" scope="col"> Status</th>
+                        <th class="govuk-table__header" scope="col">Submission date</th>
+                    </tr>
+                </thead>
+
+                @Html.EditorFor(model => model.People)
+            </table>
+            <nav class="govuk-pagination" role="navigation" aria-label="results navigation">
+                <ul class="govuk-pagination__list">
+                    @if (ViewBag.CurrentPage > 1)
+                    {
+                        <li class="govuk-pagination__item">
+                            <a class="govuk-link govuk-pagination__link" href="@Url.Action("FinaliseApplications", new { PageNumber = ViewBag.CurrentPage - 1 })">Previous</a>
+                        </li>
+                    }
+
+                    @for (int i = 1; i <= ViewBag.TotalPages; i++)
+                    {
+                        <li class="govuk-pagination__item @(ViewBag.CurrentPage == i ? "govuk-pagination__item--current" : "")">
+                            <a class="govuk-link govuk-pagination__link" href="@Url.Action("FinaliseApplications", new { PageNumber = i })">@i</a>
+                        </li>
+                    }
+
+                    @if (ViewBag.CurrentPage < ViewBag.TotalPages)
+                    {
+                        <li class="govuk-pagination__item">
+                            <a class="govuk-link govuk-pagination__link" href="@Url.Action("FinaliseApplications", new { PageNumber = ViewBag.CurrentPage + 1 })">Next</a>
+                        </li>
+                    }
+                </ul>
+            </nav>
+        }
+    </div>
+</div>

--- a/CheckYourEligibility-Admin/Views/Application/PendingApplications.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/PendingApplications.cshtml
@@ -1,71 +1,70 @@
 ﻿@using CheckYourEligibility_FrontEnd.ViewModels
 @model PeopleSelectionViewModel;
 
+@{
+    ViewData["Layout"] = "full";
+}
+
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>
 @* <a class="govuk-back-link-nolink"></a> *@
 
+<div class="moj-page-header-actions">
+    <div class="moj-page-header-actions__title">
+        <h1 class="govuk-heading-l">Pending applications (@ViewBag.TotalRecords)</h1>
+    </div>
+</div>
+<details class="govuk-details">
+    <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+            Help with this page
+        </span>
+    </summary>
+    <div class="govuk-details__text">
+        This page contains applications for free school meals that couldn't be found in the system. Review any supporting evidence parents or guardians have provided, then approve or decline to process their applications.
+    </div>
+</details>
+<div class="govuk-!-padding-bottom-3"></div>
+
 <div class="govuk-grid-row">
+
     <div class="govuk-grid-column-full">
-        <div class="moj-page-header-actions">
+        <table class="govuk-table">
+            <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th class="govuk-table__header" scope="col" id="select-all"></th>
+                    <th class="govuk-table__header" scope="col">Reference</th>
+                    <th class="govuk-table__header" scope="col">Parent / Guardian</th>
+                    <th class="govuk-table__header" scope="col">Child</th>
+                    <th class="govuk-table__header" scope="col">Child date of birth</th>
+                    <th class="govuk-table__header" scope="col"> School</th>
+                    <th class="govuk-table__header" scope="col">Submission date</th>
+                </tr>
+            </thead>
+            @Html.EditorFor(model => model.People)
+        </table>
+        <nav class="govuk-pagination" role="navigation" aria-label="results navigation">
+            <ul class="govuk-pagination__list">
+                @if (ViewBag.CurrentPage > 1)
+                {
+                    <li class="govuk-pagination__item">
+                        <a class="govuk-link govuk-pagination__link" href="@Url.Action("PendingApplications", new { PageNumber = ViewBag.CurrentPage - 1 })">Previous</a>
+                    </li>
+                }
 
-            <div class="moj-page-header-actions__title">
-                <h1 class="govuk-heading-l">Pending applications (@ViewBag.TotalRecords)</h1>
-            </div>
-        </div>
-        <details class="govuk-details">
-            <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text">
-                    Help with this page
-                </span>
-            </summary>
-            <div class="govuk-details__text">
-                This page contains applications for free school meals that couldn't be found in the system. Review any supporting evidence parents or guardians have provided, then approve or decline to process their applications.
-            </div>
-        </details>
-        <div class="govuk-!-padding-bottom-3"></div>
+                @for (int i = 1; i <= ViewBag.TotalPages; i++)
+                {
+                    <li class="govuk-pagination__item @(ViewBag.CurrentPage == i ? "govuk-pagination__item--current" : "")">
+                        <a class="govuk-link govuk-pagination__link" href="@Url.Action("PendingApplications", new { PageNumber = i })">@i</a>
+                    </li>
+                }
 
-        <div class="govuk-grid-row">
-
-            <div class="govuk-grid-column-full">
-                <table class="govuk-table">
-                    <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                            <th class="govuk-table__header" scope="col" id="select-all"></th>
-                            <th class="govuk-table__header" scope="col">Reference</th>
-                            <th class="govuk-table__header" scope="col">Parent / Guardian</th>
-                            <th class="govuk-table__header" scope="col">Child</th>
-                            <th class="govuk-table__header" scope="col">Child date of birth</th>
-                            <th class="govuk-table__header" scope="col"> School</th>
-                            <th class="govuk-table__header" scope="col">Submission date</th>
-                        </tr>
-                    </thead>
-                    @Html.EditorFor(model => model.People)
-                </table>
-                <nav class="govuk-pagination" role="navigation" aria-label="results navigation">
-                    <ul class="govuk-pagination__list">
-                        @if (ViewBag.CurrentPage > 1)
-                        {
-                            <li class="govuk-pagination__item">
-                                <a class="govuk-link govuk-pagination__link" href="@Url.Action("PendingApplications", new { PageNumber = ViewBag.CurrentPage - 1 })">Previous</a>
-                            </li>
-                        }
-
-                        @for (int i = 1; i <= ViewBag.TotalPages; i++)
-                        {
-                            <li class="govuk-pagination__item @(ViewBag.CurrentPage == i ? "govuk-pagination__item--current" : "")">
-                                <a class="govuk-link govuk-pagination__link" href="@Url.Action("PendingApplications", new { PageNumber = i })">@i</a>
-                            </li>
-                        }
-
-                        @if (ViewBag.CurrentPage < ViewBag.TotalPages)
-                        {
-                            <li class="govuk-pagination__item">
-                                <a class="govuk-link govuk-pagination__link" href="@Url.Action("PendingApplications", new { PageNumber = ViewBag.CurrentPage + 1 })">Next</a>
-                            </li>
-                        }
-                    </ul>
-                </nav>
-            </div>
-        </div>
+                @if (ViewBag.CurrentPage < ViewBag.TotalPages)
+                {
+                    <li class="govuk-pagination__item">
+                        <a class="govuk-link govuk-pagination__link" href="@Url.Action("PendingApplications", new { PageNumber = ViewBag.CurrentPage + 1 })">Next</a>
+                    </li>
+                }
+            </ul>
+        </nav>
     </div>
 </div>

--- a/CheckYourEligibility-Admin/Views/Application/Search.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/Search.cshtml
@@ -2,262 +2,189 @@
 
 @{
     ViewData["Title"] = "Application Search";
+    ViewData["Layout"] = "full";
 }
 
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>
 @* <a class="govuk-back-link-nolink"></a> *@
 
-<div class="govuk-grid-row">
+@if (!ViewData.ModelState.IsValid)
+{
+    ViewData["Title"] = "Error: Check Details";
+    <partial name="_ValidationSummary" model="ViewData.ModelState" />
+}
 
-    @if (!ViewData.ModelState.IsValid)
-    {
-        ViewData["Title"] = "Error: Check Details";
-        <partial name="_ValidationSummary" model="ViewData.ModelState" />
-    }
+<h1 class="govuk-heading-l">
+    Search all records
+</h1>
+<p>Fill in any of the fields on this page to find a free school meal record.</p>
 
-    <div class="govuk-grid-column-full">
-        <h1 class="govuk-heading-l">
-            Search all records
-        </h1>
-        <p>Fill in any of the fields on this page to find a free school meal record.</p>
-
-    </div>
-</div>
-
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-    <form asp-controller="Application" asp-action="SearchResults" method="post" class="form">
-
-
-        <!-- SEARCH BAR -->
-        <div class="cardDesign">
-
-
-            <div id="PersonName">
-
-                <div class="govuk-grid-row">
-
-
-                    <div class="govuk-grid-column-one-quarter">
-                        <div class="govuk-form-group HO-uk-margin-bottom-3">
-                            <h6 class="govuk-heading-xxs HO-uk-margin-bottom-1">
-                                Child last name
-                            </h6>
-                            <p class="govuk-error-message">
-                                <span asp-validation-for="ChildLastName"></span>
-                            </p>
-                                <input id="ChildLastName" class="govuk-input @(ViewData.ModelState["ChildLastName"]?.Errors.Count > 0 ? "govuk-input--error" : "")" type="text" name="ChildLastName" value="" placeholder="Child surname">
-
-                        </div>
-                    </div>
-                    <!--COL 1-->
-
-
-                    <div class="govuk-grid-column-one-quarter">
-                        <div class="govuk-form-group HO-uk-margin-bottom-3">
-                            <h6 class="govuk-heading-xxs HO-uk-margin-bottom-1">
-                                Parent or guardian last name
-                            </h6>
-                                <p class="govuk-error-message">
-                                    <span asp-validation-for="ParentLastName"></span>
-                                </p>
-                                <input id="ParentLastName" class="countryAutocomplete govuk-input @(ViewData.ModelState["ParentLastName"]?.Errors.Count > 0 ? "govuk-input--error" : "")" type="text" name="ParentLastName" value="" placeholder="Parent last name">
-                        </div>
-                    </div>
-
-                </div>
-
-                <div class="govuk-grid-row">
-
-
-                    <div class="govuk-grid-column-one-quarter">
-                        <div class="govuk-form-group HO-uk-margin-bottom-3">
-                            <h6 class="govuk-heading-xxs HO-uk-margin-bottom-1">
-                                Reference number
-                            </h6>
-                                <p class="govuk-error-message">
-                                    <span asp-validation-for="Reference"></span>
-                                </p>
-                                <input id="Reference" class="govuk-input @(ViewData.ModelState["Reference"]?.Errors.Count > 0 ? "govuk-input--error" : "")" type="text" name="Reference" value="" placeholder="Reference number">
-
-                        </div>
-                    </div>
-                    <!--COL 1-->
-
-
-                    <div class="govuk-grid-column-one-quarter">
-                        <div class="govuk-form-group HO-uk-margin-bottom-3">
-                            <h6 class="govuk-heading-xxs HO-uk-margin-bottom-1">
-                                Status
-                            </h6>
-
-
-                            <div class="govuk-form-group">
-
-
-                                <select class="govuk-select" id="Status" name="Status">
-
-
-                                    <option value="">All statuses</option>
-
-
-                                    <option value="Entitled">Entitled</option>
-
-
-                                    <option value="EvidenceNeeded">Evidence needed</option>
-
-
-                                    <option value="SentForReview">Sent for review</option>
-                                      
-                                    <option value="ReviewedEntitled">Reviewed entitled</option>
-
-                                    <option value="ReviewedNotEntitled">Reviewed not entitled</option>
-                                        
-                                    <option value="Receiving">Receiving entitlement</option>
-
-
-                                </select>
-
-                            </div>
-
-
-                        </div>
-                    </div>
-
-                </div>
-
-
-                <div class="govuk-grid-row">
-
-                    <div class="govuk-grid-column-one-quarter">
-
+<form asp-controller="Application" asp-action="SearchResults" method="post" class="form">
+    <!-- SEARCH BAR -->
+    <div class="cardDesign">
+        <div id="PersonName">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-quarter">
+                    <div class="govuk-form-group HO-uk-margin-bottom-3">
+                        <h6 class="govuk-heading-xxs HO-uk-margin-bottom-1">
+                            Child last name
+                        </h6>
+                        <p class="govuk-error-message">
+                            <span asp-validation-for="ChildLastName"></span>
+                        </p>
+                        <input id="ChildLastName" class="govuk-input @(ViewData.ModelState["ChildLastName"]?.Errors.Count > 0 ? "govuk-input--error" : "")" type="text" name="ChildLastName" value="" placeholder="Child surname">
 
                     </div>
                 </div>
+                <!--COL 1-->
 
-
-                <!-- CHILD -->
-                <div class="govuk-grid-row">
-
-                    <div class="govuk-grid-column-one-quarter">
-
-
-                        <div class="govuk-form-group HO-uk-margin-bottom-3">
-                            <fieldset class="govuk-fieldset" role="group" aria-describedby="passport-issued-hint">
-                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                                    Child date of birth
-                                </legend>
-                                    <span asp-validation-for="ChildDob" class="govuk-error-message"></span>
-                                <div class="govuk-date-input" id="ChildDob">
-                                    <div class="govuk-date-input__item">
-                                        <div class="govuk-form-group">
-                                            <label class="govuk-label govuk-date-input__label" for="ChildDOBDay">
-                                                Day
-                                            </label>
-                                                <input asp-for="ChildDobDay" class="govuk-input govuk-date-input__input govuk-input--width-2 @(ViewData.ModelState["ChildDob.ChildDobDay"]?.Errors.Count > 0 ? "govuk-input--error" : "")" id="ChildDobDay" name="ChildDobDay" inputmode="text" maxlength="2" type="text" inputmode="numeric" aria-label="Day">
-                                            </div>
-
-
-                                    </div>
-                                    <div class="govuk-date-input__item">
-                                        <div class="govuk-form-group">
-                                            <label class="govuk-label govuk-date-input__label" for="ChildDobMonth">
-                                                Month
-                                            </label>
-                                                <input asp-for="ChildDobMonth" class="govuk-input govuk-date-input__input govuk-input--width-2 @(ViewData.ModelState["ChildDob.ChildDobMonth"]?.Errors.Count > 0 ? "govuk-input--error" : "")" id="ChildDobMonth" name="ChildDobMonth" inputmode="text" maxlength="2" type="text" inputmode="numeric" aria-label="Month">
-                                            </div>
-                                    </div>
-                                    <div class="govuk-date-input__item">
-                                        <div class="govuk-form-group">
-                                            <label class="govuk-label govuk-date-input__label" for="ChildDobYear">
-                                                Year
-                                            </label>
-                                                <input asp-for="ChildDobYear" class="govuk-input govuk-date-input__input govuk-input--width-2 @(ViewData.ModelState["ChildDob.ChildDob"]?.Errors.Count > 0 ? "govuk-input--error" : "")" id="ChildDobYear" name="ChildDobYear" inputmode="text" maxlength="4" type="text" inputmode="numeric" aria-label="Year">
-                                            </div>
-
-                                    </div>
-                                </div>
-
-                            </fieldset>
-                        </div>
+                <div class="govuk-grid-column-one-quarter">
+                    <div class="govuk-form-group HO-uk-margin-bottom-3">
+                        <h6 class="govuk-heading-xxs HO-uk-margin-bottom-1">
+                            Parent or guardian last name
+                        </h6>
+                        <p class="govuk-error-message">
+                            <span asp-validation-for="ParentLastName"></span>
+                        </p>
+                        <input id="ParentLastName" class="countryAutocomplete govuk-input @(ViewData.ModelState["ParentLastName"]?.Errors.Count > 0 ? "govuk-input--error" : "")" type="text" name="ParentLastName" value="" placeholder="Parent last name">
                     </div>
-
-
                 </div>
+            </div>
 
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-one-quarter">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-quarter">
+                    <div class="govuk-form-group HO-uk-margin-bottom-3">
+                        <h6 class="govuk-heading-xxs HO-uk-margin-bottom-1">
+                            Reference number
+                        </h6>
+                        <p class="govuk-error-message">
+                            <span asp-validation-for="Reference"></span>
+                        </p>
+                        <input id="Reference" class="govuk-input @(ViewData.ModelState["Reference"]?.Errors.Count > 0 ? "govuk-input--error" : "")" type="text" name="Reference" value="" placeholder="Reference number">
 
+                    </div>
+                </div>
+                <!--COL 1-->
+
+                <div class="govuk-grid-column-one-quarter">
+                    <div class="govuk-form-group HO-uk-margin-bottom-3">
+                        <h6 class="govuk-heading-xxs HO-uk-margin-bottom-1">
+                            Status
+                        </h6>
 
                         <div class="govuk-form-group">
-                            <fieldset class="govuk-fieldset" role="group" aria-describedby="passport-issued-hint">
-                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                                    Parent or guardian date of birth
-                                </legend>
-                                    <span asp-validation-for="ParentDob" class="govuk-error-message"></span>
-                                <div class="govuk-date-input" id="ParentDob">
-                                    <div class="govuk-date-input__item">
-                                        <div class="govuk-form-group">
-                                            <label class="govuk-label govuk-date-input__label" for="PGDOBDay">
-                                                Day
-                                            </label>
-                                                <input asp-for="PGDobDay" class="govuk-input govuk-date-input__input govuk-input--width-2 @(ViewData.ModelState["ParentDob.PGDobDay"]?.Errors.Count > 0 ? "govuk-input--error" : "")" id="PGDobDay" name="PGDobDay" inputmode="text" maxlength="2" type="text" inputmode="numeric" aria-label="Day">
-                                        </div>
-
-                                    </div>
-                                    <div class="govuk-date-input__item">
-                                        <div class="govuk-form-group">
-                                                <label class="govuk-label govuk-date-input__label" for="PGDOBMonth">
-                                                Month
-                                            </label>
-                                                <input asp-for="PGDobMonth" class="govuk-input govuk-date-input__input govuk-input--width-2 @(ViewData.ModelState["ParentDob.PGDobMonth"]?.Errors.Count > 0 ? "govuk-input--error" : "")" id="PGDobMonth" name="PGDobMonth" inputmode="text" maxlength="2" type="text" inputmode="numeric" aria-label="Month">
-                                        </div>
-                                    </div>
-                                    <div class="govuk-date-input__item">
-                                        <div class="govuk-form-group">
-                                                <label class="govuk-label govuk-date-input__label" for="PGDOBYear">
-                                                Year
-                                            </label>
-                                                <input asp-for="PGDobYear" class="govuk-input govuk-date-input__input govuk-input--width-2 @(ViewData.ModelState["ParentDob.PGDobYear"]?.Errors.Count > 0 ? "govuk-input--error" : "")" id="PGDobYear" name="PGDobYear" inputmode="text" maxlength="4" type="text" inputmode="numeric" aria-label="Year">
-                                        </div>
-                                    </div>
-                                </div>
-
-                            </fieldset>
+                            <select class="govuk-select" id="Status" name="Status">
+                                <option value="">All statuses</option>
+                                <option value="Entitled">Entitled</option>
+                                <option value="EvidenceNeeded">Evidence needed</option>
+                                <option value="SentForReview">Sent for review</option>
+                                <option value="ReviewedEntitled">Reviewed entitled</option>
+                                <option value="ReviewedNotEntitled">Reviewed not entitled</option>
+                                <option value="Receiving">Receiving entitlement</option>
+                            </select>
                         </div>
                     </div>
                 </div>
-                <!-- SEX -->
-                <div class="govuk-grid-row">
+            </div>
 
-                    <div class="govuk-grid-column-full">
-
-                        <form action="eligible-list">
-                            <button class="govuk-button govuk-button HO-button-white moj-button-menu__item govuk-!-margin-top-6" data-module="govuk-button">
-                                Generate results
-                            </button>
-
-                        </form>
-
-
-                    </div>
-
-
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-quarter">
                 </div>
+            </div>
 
+            <!-- CHILD -->
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-quarter">
+                    <div class="govuk-form-group HO-uk-margin-bottom-3">
+                        <fieldset class="govuk-fieldset" role="group" aria-describedby="passport-issued-hint">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                                Child date of birth
+                            </legend>
+                            <span asp-validation-for="ChildDob" class="govuk-error-message"></span>
+                            <div class="govuk-date-input" id="ChildDob">
+                                <div class="govuk-date-input__item">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label govuk-date-input__label" for="ChildDOBDay">
+                                            Day
+                                        </label>
+                                        <input asp-for="ChildDobDay" class="govuk-input govuk-date-input__input govuk-input--width-2 @(ViewData.ModelState["ChildDob.ChildDobDay"]?.Errors.Count > 0 ? "govuk-input--error" : "")" id="ChildDobDay" name="ChildDobDay" inputmode="text" maxlength="2" type="text" inputmode="numeric" aria-label="Day">
+                                    </div>
+                                </div>
+                                <div class="govuk-date-input__item">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label govuk-date-input__label" for="ChildDobMonth">
+                                            Month
+                                        </label>
+                                        <input asp-for="ChildDobMonth" class="govuk-input govuk-date-input__input govuk-input--width-2 @(ViewData.ModelState["ChildDob.ChildDobMonth"]?.Errors.Count > 0 ? "govuk-input--error" : "")" id="ChildDobMonth" name="ChildDobMonth" inputmode="text" maxlength="2" type="text" inputmode="numeric" aria-label="Month">
+                                    </div>
+                                </div>
+                                <div class="govuk-date-input__item">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label govuk-date-input__label" for="ChildDobYear">
+                                            Year
+                                        </label>
+                                        <input asp-for="ChildDobYear" class="govuk-input govuk-date-input__input govuk-input--width-2 @(ViewData.ModelState["ChildDob.ChildDob"]?.Errors.Count > 0 ? "govuk-input--error" : "")" id="ChildDobYear" name="ChildDobYear" inputmode="text" maxlength="4" type="text" inputmode="numeric" aria-label="Year">
+                                    </div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+            </div>
+
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-quarter">
+                    <div class="govuk-form-group">
+                        <fieldset class="govuk-fieldset" role="group" aria-describedby="passport-issued-hint">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                                Parent or guardian date of birth
+                            </legend>
+                            <span asp-validation-for="ParentDob" class="govuk-error-message"></span>
+                            <div class="govuk-date-input" id="ParentDob">
+                                <div class="govuk-date-input__item">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label govuk-date-input__label" for="PGDOBDay">
+                                            Day
+                                        </label>
+                                        <input asp-for="PGDobDay" class="govuk-input govuk-date-input__input govuk-input--width-2 @(ViewData.ModelState["ParentDob.PGDobDay"]?.Errors.Count > 0 ? "govuk-input--error" : "")" id="PGDobDay" name="PGDobDay" inputmode="text" maxlength="2" type="text" inputmode="numeric" aria-label="Day">
+                                    </div>
+                                </div>
+                                <div class="govuk-date-input__item">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label govuk-date-input__label" for="PGDOBMonth">
+                                            Month
+                                        </label>
+                                        <input asp-for="PGDobMonth" class="govuk-input govuk-date-input__input govuk-input--width-2 @(ViewData.ModelState["ParentDob.PGDobMonth"]?.Errors.Count > 0 ? "govuk-input--error" : "")" id="PGDobMonth" name="PGDobMonth" inputmode="text" maxlength="2" type="text" inputmode="numeric" aria-label="Month">
+                                    </div>
+                                </div>
+                                <div class="govuk-date-input__item">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label govuk-date-input__label" for="PGDOBYear">
+                                            Year
+                                        </label>
+                                        <input asp-for="PGDobYear" class="govuk-input govuk-date-input__input govuk-input--width-2 @(ViewData.ModelState["ParentDob.PGDobYear"]?.Errors.Count > 0 ? "govuk-input--error" : "")" id="PGDobYear" name="PGDobYear" inputmode="text" maxlength="4" type="text" inputmode="numeric" aria-label="Year">
+                                    </div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+            </div>
+
+            <!-- SEX -->
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form action="eligible-list">
+                        <button class="govuk-button govuk-button HO-button-white moj-button-menu__item govuk-!-margin-top-6" data-module="govuk-button">
+                            Generate results
+                        </button>
+                    </form>
+                </div>
+            </div>
 
             <!-- EXPLANATIONS REMOVED FOR V2 -->
 
-
-            </div>
-            <!--END SHOW/HIDE -->
-
-
         </div>
-    </form>
-
-    <!-- END CARD // SEARCH BAR -->
-
-
+        <!--END SHOW/HIDE -->
     </div>
-</div>
+</form>

--- a/CheckYourEligibility-Admin/Views/Application/SearchResults.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/SearchResults.cshtml
@@ -1,116 +1,112 @@
 ﻿@using CheckYourEligibility_FrontEnd.ViewModels
 @model PeopleSelectionViewModel;
 
+@{
+    ViewData["Layout"] = "full";
+}
+
 @* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a>*@
 <a class="govuk-back-link-nolink"></a>
 
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+<h1 class="govuk-heading-l">
+    Search results (@ViewBag.TotalRecords)
+</h1>
 
-        <div class="govuk-grid-column-full">
-            <h1 class="govuk-heading-l">
-                Search results (@ViewBag.TotalRecords)
-            </h1>
+<p><a href="search">Search again</a> </p>
+@if (Model.People != null && Model.People.Any())
+{
+    <table class="govuk-table">
+        <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="col" id="select-all"></th>
+                <th class="govuk-table__header" scope="col">Reference</th>
+                <th class="govuk-table__header" scope="col">Parent / Guardian</th>
+                <th class="govuk-table__header" scope="col">Child</th>
+                <th class="govuk-table__header" scope="col">Child DOB</th>
+                <th class="govuk-table__header" scope="col"> Status</th>
+                <th class="govuk-table__header" scope="col">Submission date</th>
+            </tr>
+        </thead>
+        @Html.EditorFor(model => model.People)
+    </table>
 
-            <p><a href="search">Search again</a> </p>
-            @if (Model.People != null && Model.People.Any())
+    <nav class="govuk-pagination" aria-label="Pagination">
+        @if (ViewBag.CurrentPage > 1)
+        {
+            <div class="govuk-pagination__prev">
+                <a class="govuk-link govuk-pagination__link" href="@Url.Action("SearchResults", new { PageNumber = ViewBag.CurrentPage - 1 })" rel="prev">
+                    <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                        <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+                    </svg>
+                    <span class="govuk-pagination__link-title">
+                        Previous<span class="govuk-visually-hidden"> page</span>
+                    </span>
+                </a>
+            </div>
+        }
+        <ul class="govuk-pagination__list">
+            @if (ViewBag.CurrentPage > 1)
             {
-                <table class="govuk-table">
-                    <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                            <th class="govuk-table__header" scope="col" id="select-all"></th>
-                            <th class="govuk-table__header" scope="col">Reference</th>
-                            <th class="govuk-table__header" scope="col">Parent / Guardian</th>
-                            <th class="govuk-table__header" scope="col">Child</th>
-                            <th class="govuk-table__header" scope="col">Child DOB</th>
-                            <th class="govuk-table__header" scope="col"> Status</th>
-                            <th class="govuk-table__header" scope="col">Submission date</th>
-                        </tr>
-                    </thead>
-                    @Html.EditorFor(model => model.People)
-                </table>
-
-                <nav class="govuk-pagination" aria-label="Pagination">
-                    @if (ViewBag.CurrentPage > 1)
-                    {
-                        <div class="govuk-pagination__prev">
-                            <a class="govuk-link govuk-pagination__link" href="@Url.Action("SearchResults", new { PageNumber = ViewBag.CurrentPage - 1 })" rel="prev">
-                                <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-                                    <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-                                </svg>
-                                <span class="govuk-pagination__link-title">
-                                    Previous<span class="govuk-visually-hidden"> page</span>
-                                </span>
-                            </a>
-                        </div>
-                    }
-                    <ul class="govuk-pagination__list">
-                        @if (ViewBag.CurrentPage > 1)
-                        {
-                            <li class="govuk-pagination__item">
-                                <a class="govuk-link govuk-pagination__link" href="/Application/SearchResults?PageNumber=1" aria-label="Page 1">
-                                    1
-                                </a>
-                            </li>
-                            <li class="govuk-pagination__item govuk-pagination__item--ellipses">
-                                &ctdot;
-                            </li>
-                        }
-                        @for (int i = 1; i <= ViewBag.TotalPages; i++)
-                        {
-
-                            if (ViewBag.CurrentPage == i)
-                            {
-                                if (i > 2)
-                                {
-                                    <li class="govuk-pagination__item">
-                                        <a class="govuk-link govuk-pagination__link" aria-label="Page @(i-1)" aria-current="page" href="@Url.Action("SearchResults", new { PageNumber = (i-1) })">@(i - 1)</a>
-                                    </li>
-                                }
-
-                                <li class="govuk-pagination__item @(ViewBag.CurrentPage == i ? "govuk-pagination__item--current" : "")">
-                                    <a class="govuk-link govuk-pagination__link" aria-label="Page @i" aria-current="page" href="@Url.Action("SearchResults", new { PageNumber = i })">@i</a>
-                                </li>
-
-                                if (i < ViewBag.TotalPages - 1)
-                                {
-                                    <li class="govuk-pagination__item">
-                                        <a class="govuk-link govuk-pagination__link" aria-label="Page @(i+1)" aria-current="page" href="@Url.Action("SearchResults", new { PageNumber = (i+1) })">@(i + 1)</a>
-                                    </li>
-                                }
-                            }
-                        }
-                        @if (ViewBag.CurrentPage < ViewBag.TotalPages)
-                        {
-                            <li class="govuk-pagination__item govuk-pagination__item--ellipses">
-                                &ctdot;
-                            </li>
-                            <li class="govuk-pagination__item">
-                                <a class="govuk-link govuk-pagination__link" href="/Application/SearchResults?PageNumber=@ViewBag.TotalPages" aria-label="Page @ViewBag.TotalPages">
-                                    @ViewBag.TotalPages
-                                </a>
-                            </li>
-                        }
-                    </ul>
-                    @if (ViewBag.CurrentPage < ViewBag.TotalPages)
-                    {
-                        <div class="govuk-pagination__next">
-                            <a class="govuk-link govuk-pagination__link" href="@Url.Action("SearchResults", new { PageNumber = ViewBag.CurrentPage + 1 })" rel="next">
-                                <span class="govuk-pagination__link-title">
-                                    Next<span class="govuk-visually-hidden"> page</span>
-                                </span>
-                                <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-                                    <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-                                </svg>
-                            </a>
-                        </div>
-                    }
-                </nav>
+                <li class="govuk-pagination__item">
+                    <a class="govuk-link govuk-pagination__link" href="/Application/SearchResults?PageNumber=1" aria-label="Page 1">
+                        1
+                    </a>
+                </li>
+                <li class="govuk-pagination__item govuk-pagination__item--ellipses">
+                    &ctdot;
+                </li>
             }
-            else
+            @for (int i = 1; i <= ViewBag.TotalPages; i++)
             {
-                <p>No results found.</p>
+                if (ViewBag.CurrentPage == i)
+                {
+                    if (i > 2)
+                    {
+                        <li class="govuk-pagination__item">
+                            <a class="govuk-link govuk-pagination__link" aria-label="Page @(i-1)" aria-current="page" href="@Url.Action("SearchResults", new { PageNumber = (i-1) })">@(i - 1)</a>
+                        </li>
+                    }
+
+                    <li class="govuk-pagination__item @(ViewBag.CurrentPage == i ? "govuk-pagination__item--current" : "")">
+                        <a class="govuk-link govuk-pagination__link" aria-label="Page @i" aria-current="page" href="@Url.Action("SearchResults", new { PageNumber = i })">@i</a>
+                    </li>
+
+                    if (i < ViewBag.TotalPages - 1)
+                    {
+                        <li class="govuk-pagination__item">
+                            <a class="govuk-link govuk-pagination__link" aria-label="Page @(i+1)" aria-current="page" href="@Url.Action("SearchResults", new { PageNumber = (i+1) })">@(i + 1)</a>
+                        </li>
+                    }
+                }
             }
-        </div>
-    </div>
-</div>
+            @if (ViewBag.CurrentPage < ViewBag.TotalPages)
+            {
+                <li class="govuk-pagination__item govuk-pagination__item--ellipses">
+                    &ctdot;
+                </li>
+                <li class="govuk-pagination__item">
+                    <a class="govuk-link govuk-pagination__link" href="/Application/SearchResults?PageNumber=@ViewBag.TotalPages" aria-label="Page @ViewBag.TotalPages">
+                        @ViewBag.TotalPages
+                    </a>
+                </li>
+            }
+        </ul>
+        @if (ViewBag.CurrentPage < ViewBag.TotalPages)
+        {
+            <div class="govuk-pagination__next">
+                <a class="govuk-link govuk-pagination__link" href="@Url.Action("SearchResults", new { PageNumber = ViewBag.CurrentPage + 1 })" rel="next">
+                    <span class="govuk-pagination__link-title">
+                        Next<span class="govuk-visually-hidden"> page</span>
+                    </span>
+                    <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+                    </svg>
+                </a>
+            </div>
+        }
+    </nav>
+}
+else
+{
+    <p>No results found.</p>
+}

--- a/CheckYourEligibility-Admin/Views/BulkCheck/BulkOutcome/Error_Data_Issue.cshtml
+++ b/CheckYourEligibility-Admin/Views/BulkCheck/BulkOutcome/Error_Data_Issue.cshtml
@@ -4,8 +4,8 @@
 
 <div id="content" data-type="ErrorData">
     <a class="govuk-back-link-nolink"></a>
-    
-    <div class="govuk-error-summary" data-module="govuk-error-summary">
+
+    <div class="govuk-error-summary govuk-grid-column-full" data-module="govuk-error-summary">
         <div role="alert">
             <h2 class="govuk-error-summary__title">
                 Error – Parent data issue
@@ -18,13 +18,13 @@
                     @Html.Raw(@TempData["BulkParentCheckItemsErrors"])
 
                     @if (Convert.ToInt32(@TempData["BulkParentCheckItemsLineMoreErrors"]) > 0)
-                        {
+                    {
                         <li>
                             <strong>There are also issues on @TempData["BulkParentCheckItemsLineMoreErrors"] more lines</strong>
                         </li>
-                        }
-                        
-                    
+                    }
+
+
                 </ul>
             </div>
         </div>

--- a/CheckYourEligibility-Admin/Views/BulkCheck/BulkOutcome/Error_Not_Accepted.cshtml
+++ b/CheckYourEligibility-Admin/Views/BulkCheck/BulkOutcome/Error_Not_Accepted.cshtml
@@ -5,7 +5,7 @@
 <div id="content" data-type="ErrorNotAccepted">
     <a class="govuk-back-link-nolink"></a>
 
-    <div class="govuk-error-summary" data-module="govuk-error-summary" id="content" data-type="success">
+    <div class="govuk-error-summary govuk-grid-column-full" data-module="govuk-error-summary" id="content" data-type="success">
         <div role="alert">
             <h2 class="govuk-error-summary__title">
                 Error – File not accepted

--- a/CheckYourEligibility-Admin/Views/BulkCheck/BulkOutcome/Success.cshtml
+++ b/CheckYourEligibility-Admin/Views/BulkCheck/BulkOutcome/Success.cshtml
@@ -1,30 +1,34 @@
 ﻿@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<div id="content" data-type="success">
-    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Success
-            </h2>
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-full" data-type="success">
+
+        <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    Success
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <h1 class="govuk-notification-banner__heading">
+                    Checks completed
+                </h1>
+                <p class="govuk-body">Now download the checked file to see which parents can claim free school meals for their children.</p>
+                <p>free-school-meal-outcomes-YYYYMMDD.csv</p>
+
+                @Html.ActionLink("Download", "Bulk_check_download", "BulkCheck", null, new { @class = "govuk-button" })
+            </div>
         </div>
-        <div class="govuk-notification-banner__content">
-            <h1 class="govuk-notification-banner__heading">
-                Checks completed
-            </h1>
-            <p class="govuk-body">Now download the checked file to see which parents can claim free school meals for their children.</p>
-            <p>free-school-meal-outcomes-YYYYMMDD.csv</p>
 
-             @Html.ActionLink("Download", "Bulk_check_download", "BulkCheck",null, new { @class = "govuk-button" })
-
-        </div>
-
-    </div>
-        <h1>Result explainer</h1>
+        <h1 class="govuk-heading-l">Result explainer</h1>
         <p><strong>Entitled</strong> – The children of this parent or guardian are entitled to free school meals.</p>
         <p><strong>May not be entitled</strong> – The children of this parent or guardian may not be entitled to free school meals. To appeal, provide evidence to support your local authority in making a decision. View the list of acceptable evidence. </p>
         <p><strong>Could not check</strong>  – This parent or guardian’s personal information doesn’t match the departmental records. Either their data was entered incorrectly or their entitlement isn’t currently updated on the system.</p>
         <p><strong>Error</strong> – There was a problem accessing this parent or guardian’s data to obtain a result. </p>
-    <p>@Html.ActionLink("Return to dashboard", "Index", "Home")</p>
-    <p> @Html.ActionLink("Sign Out", "SignOut", "Account")</p>
+
+
+        <p>@Html.ActionLink("Return to dashboard", "Index", "Home")</p>
+        <p> @Html.ActionLink("Sign Out", "SignOut", "Account")</p>
+    </div>
 </div>

--- a/CheckYourEligibility-Admin/Views/BulkCheck/Bulk_Check.cshtml
+++ b/CheckYourEligibility-Admin/Views/BulkCheck/Bulk_Check.cshtml
@@ -2,6 +2,7 @@
 
 @{
     ViewData["Title"] = "Check Details";
+    ViewData["Layout"] = "two_thirds";
     var errorMessage = TempData["ErrorMessage"] as string;
 }
 
@@ -15,35 +16,31 @@
 }
 
 <form asp-controller="BulkCheck" asp-action="Bulk_Check" method="post" enctype="multipart/form-data">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">Run a bulk check for multiple parents or guardians</h1>
-            <p>Upload a template with details of the parents or guardians who applied for free school meals.</p>
-            <h2 class="govuk-heading-m">Running a bulk check</h2>
-            <ol class="govuk-list govuk-list--number">
-                <li>Download the <a href="~/documents/bulkchecktemplate.csv" class="govuk-link">bulk check template</a> (0.11 kb) </li>
-                <li>Add the details of all parents you need to check, including: Name, Date of birth, National Insurance number or Asylum support reference number.</li>
-                <li>Save it as a CSV file.</li>
-                <li>Upload the completed template on this page on this page and perform checks.</li>
-                <li>You’ll be given a file to download containing results.</li>
-            </ol>
-            <h2 class="govuk-heading-m">Upload a completed template and run a check</h2>
-            <p>The bulk check template must be fully completed and in CSV format.</p>
-            <div class="govuk-form-group @(string.IsNullOrEmpty(errorMessage) ? "" : "govuk-form-group--error")">
-                @if (!string.IsNullOrEmpty(errorMessage))
-                {
-                    <p id="file-upload-1-error" class="govuk-error-message">
-                        <span class="govuk-visually-hidden">Error:</span> @errorMessage
-                    </p>
-                }
-                <input class="govuk-file-upload @(string.IsNullOrEmpty(errorMessage) ? "" : "govuk-file-upload--error")" id="file-upload-1" name="fileUpload" type="file" accept=".csv" aria-describedby="file-upload-1-error">
-            </div>
-
-            <button class="govuk-button" data-module="govuk-button">
-                Run check
-            </button>
-        </div>
+    <h1 class="govuk-heading-l">Run a bulk check for multiple parents or guardians</h1>
+    <p>Upload a template with details of the parents or guardians who applied for free school meals.</p>
+    <h2 class="govuk-heading-m">Running a bulk check</h2>
+    <ol class="govuk-list govuk-list--number">
+        <li>Download the <a href="~/documents/bulkchecktemplate.csv" class="govuk-link">bulk check template</a> (0.11 kb) </li>
+        <li>Add the details of all parents you need to check, including: Name, Date of birth, National Insurance number or Asylum support reference number.</li>
+        <li>Save it as a CSV file.</li>
+        <li>Upload the completed template on this page on this page and perform checks.</li>
+        <li>You’ll be given a file to download containing results.</li>
+    </ol>
+    <h2 class="govuk-heading-m">Upload a completed template and run a check</h2>
+    <p>The bulk check template must be fully completed and in CSV format.</p>
+    <div class="govuk-form-group @(string.IsNullOrEmpty(errorMessage) ? "" : "govuk-form-group--error")">
+        @if (!string.IsNullOrEmpty(errorMessage))
+        {
+            <p id="file-upload-1-error" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span> @errorMessage
+            </p>
+        }
+        <input class="govuk-file-upload @(string.IsNullOrEmpty(errorMessage) ? "" : "govuk-file-upload--error")" id="file-upload-1" name="fileUpload" type="file" accept=".csv" aria-describedby="file-upload-1-error">
     </div>
+
+    <button class="govuk-button" data-module="govuk-button">
+        Run check
+    </button>
 </form>
 
 <script src="/js/validationSummary.js"></script>

--- a/CheckYourEligibility-Admin/Views/BulkCheck/Bulk_Loader.cshtml
+++ b/CheckYourEligibility-Admin/Views/BulkCheck/Bulk_Loader.cshtml
@@ -1,5 +1,6 @@
 ﻿@{
     ViewData["Title"] = "Checking Loader";
+    ViewData["Layout"] = "full";
 }
 
 @* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a>*@

--- a/CheckYourEligibility-Admin/Views/Check/ApplicationsRegistered.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/ApplicationsRegistered.cshtml
@@ -3,6 +3,7 @@
 
 @{
     ViewData["Title"] = "confirmation-entitled";
+    ViewData["Layout"] = "full";
 }
 
 @* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@

--- a/CheckYourEligibility-Admin/Views/Check/Check_Answers.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Check_Answers.cshtml
@@ -3,6 +3,7 @@
 
 @{
     ViewData["Title"] = "Check Answers";
+    ViewData["Layout"] = "full";
 }
 
 @* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a>*@

--- a/CheckYourEligibility-Admin/Views/Check/Enter_Child_Details.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Enter_Child_Details.cshtml
@@ -2,6 +2,7 @@
 
 @{
     ViewData["Title"] = "Provide details of your children";
+    ViewData["Layout"] = "two_thirds";
     var childIndex = TempData["childIndex"] as int?;
 }
 

--- a/CheckYourEligibility-Admin/Views/Check/Enter_Details.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Enter_Details.cshtml
@@ -2,6 +2,7 @@
 
 @{
     ViewData["Title"] = "Check Details";
+    ViewData["Layout"] = "two_thirds";
 }
 
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>

--- a/CheckYourEligibility-Admin/Views/Check/Loader.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Loader.cshtml
@@ -1,5 +1,6 @@
 @{
     ViewData["Title"] = "Checking Loader";
+    ViewData["Layout"] = "full";
 }
 
 @* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a>*@

--- a/CheckYourEligibility-Admin/Views/Check/Outcome/Eligible.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Outcome/Eligible.cshtml
@@ -1,8 +1,8 @@
 ﻿<a class="govuk-back-link" @Html.ActionLink("Back", "Enter_Details", "Check")</a>
 @* <a class="govuk-back-link-nolink"></a> *@
 
-<div class="govuk-grid-row" id="content" data-type="Eligible">
-    <div class="govuk-grid-column-full">
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-two-thirds" data-type="Eligible">
         <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/CheckYourEligibility-Admin/Views/Check/Outcome/Eligible_LA.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Outcome/Eligible_LA.cshtml
@@ -1,8 +1,8 @@
 ﻿@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<div class="govuk-grid-row" id="content" data-type="Eligible_LA">
-    <div class="govuk-grid-column-full">
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-two-thirds" data-type="Eligible_LA">
         <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/CheckYourEligibility-Admin/Views/Check/Outcome/Not_Eligible.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Outcome/Not_Eligible.cshtml
@@ -1,30 +1,31 @@
 ﻿<a class="govuk-back-link" @Html.ActionLink("Back", "Enter_Details", "Check")</a>
 @* <a class="govuk-back-link-nolink"></a> *@
 
-<div id="content" data-type="Not_Eligible">
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                May not be eligible
-            </h2>
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-two-thirds" data-type="Not_Eligible">
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    May not be eligible
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p class="govuk-notification-banner__heading">
+                    The children of this parent or guardian may not be eligible for free school meals.
+                </p>
+                <p class="govuk-body">The parent or guardian can appeal, but you’ll need to ask them for supporting evidence.</p>
+                <p class="govuk-body"><a class="govuk-link" rel="noreferrer noopener" target="_blank" href="~/Home/Guidance">See a complete list of acceptable evidence (opens in new tab)</a>.</p>
+            </div>
         </div>
-        <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">
-                The children of this parent or guardian may not be eligible for free school meals.
-            </p>
-            <p class="govuk-body">The parent or guardian can appeal, but you’ll need to ask them for supporting evidence.</p>
-            <p class="govuk-body"><a class="govuk-link" rel="noreferrer noopener" target="_blank" href="~/Home/Guidance">See a complete list of acceptable evidence (opens in new tab)</a>.</p>
-        </div>
+
+        <h1 class="govuk-heading-l">Make an appeal</h1>
+
+        <p class="govuk-body">You'll be told how to send the local authority supporting evidence after you've made an appeal.</p>
+
+        @Html.ActionLink("Appeal now", "Enter_Child_Details", "Check", null, new { @class = "govuk-button" })
+
+        <p class="govuk-body">Alternatively, you can contact the Department for Education support desk at <a href="mailto:ecs.admin@education.gov.uk">ecs.admin@education.gov.uk</a> to request a separate check.</p>
+
+        <p>@Html.ActionLink("Return to dashboard", "Index", "Home")</p>
     </div>
-
-    <h1 class="govuk-heading-l">Make an appeal</h1>
-
-    <p class="govuk-body">You'll be told how to send the local authority supporting evidence after you've made an appeal.</p>
-
-    @Html.ActionLink("Appeal now", "Enter_Child_Details", "Check", null, new { @class = "govuk-button" })
-
-    <p class="govuk-body">Alternatively, you can contact the Department for Education support desk at <a href="mailto:ecs.admin@education.gov.uk">ecs.admin@education.gov.uk</a> to request a separate check.</p>
-
-    <p>@Html.ActionLink("Return to dashboard", "Index", "Home")</p>
-
 </div>

--- a/CheckYourEligibility-Admin/Views/Check/Outcome/Not_Eligible_LA.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Outcome/Not_Eligible_LA.cshtml
@@ -1,32 +1,34 @@
 ﻿@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<div id="content" data-type="Not_Eligible_LA">
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                May not be eligible
-            </h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">
-                The children of this parent or guardian may not be eligible for free school meals.
-            </p>
-            <p class="govuk-body">The parent or guardian can appeal, but you’ll need to review their supporting evidence.</p>
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-two-thirds" data-type="Not_Eligible_LA">
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    May not be eligible
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p class="govuk-notification-banner__heading">
+                    The children of this parent or guardian may not be eligible for free school meals.
+                </p>
+                <p class="govuk-body">The parent or guardian can appeal, but you’ll need to review their supporting evidence.</p>
 
+            </div>
         </div>
+
+        <h1 class="govuk-heading-l">Review supporting evidence</h1>
+        <p class="govuk-body">If the parent appeals, you’ll need to review their supporting evidence.</p>
+        <p class="govuk-body"><a class="govuk-link" rel="noreferrer noopener" target="_blank" href="~/Home/Guidance">See a complete list of acceptable evidence (opens in new tab)</a>.</p>
+
+        <h2 class="govuk-heading-m">If you have not received any evidence</h2>
+        <p class="govuk-body">You can either:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>contact the relevant school to ask them to collect it from the parent or guardian</li>
+            <li>email the Department for Education support desk to request a separate check at ecs.admin@education.gov.uk</li>
+        </ul>
+
+        <p>@Html.ActionLink("Return to dashboard", "Index", "Home")</p>
     </div>
-
-    <h1 class="govuk-heading-l">Review supporting evidence</h1>
-    <p class="govuk-body">If the parent appeals, you’ll need to review their supporting evidence.</p>
-    <p class="govuk-body"><a class="govuk-link" rel="noreferrer noopener" target="_blank" href="~/Home/Guidance">See a complete list of acceptable evidence (opens in new tab)</a>.</p>
-
-    <h2 class="govuk-heading-m">If you have not received any evidence</h2>
-    <p class="govuk-body">You can either:</p>
-    <ul class="govuk-list govuk-list--bullet">
-        <li>contact the relevant school to ask them to collect it from the parent or guardian</li>
-        <li>email the Department for Education support desk to request a separate check at ecs.admin@education.gov.uk</li>
-    </ul>
-
-    <p>@Html.ActionLink("Return to dashboard", "Index", "Home")</p>
 </div>

--- a/CheckYourEligibility-Admin/Views/Check/Outcome/Not_Found.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Outcome/Not_Found.cshtml
@@ -1,20 +1,21 @@
 ﻿@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<div id="content" data-type="Not_Found">
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-two-thirds" data-type="Not_Found">
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    Check failed
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p class="govuk-notification-banner__heading">The personal information you entered does not match departmental records.</p>
+            </div>
+        </div>
 
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Check failed
-            </h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">The personal information you entered does not match departmental records.</p>
-        </div>
+        <h1 class="govuk-heading-l">Check the details and try again</h1>
+        <p>@Html.ActionLink("Try again", "Enter_Details", "Check")</p>
+        <p>@Html.ActionLink("Return to dashboard", "Index", "Home")</p>
     </div>
-
-    <h1 class="govuk-heading-l">Check the details and try again</h1>
-    <p>@Html.ActionLink("Try again", "Enter_Details", "Check")</p>
-    <p>@Html.ActionLink("Return to dashboard", "Index", "Home")</p>
 </div>

--- a/CheckYourEligibility-Admin/Views/Check/Outcome/Technical_Error.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Outcome/Technical_Error.cshtml
@@ -1,21 +1,21 @@
 ﻿<a class="govuk-back-link" @Html.ActionLink("Back", "Enter_Details", "Check")</a>
 @* <a class="govuk-back-link-nolink"></a> *@
 
-<div id="content" data-type="Technical_Error">
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-two-thirds" data-type="Technical_Error">
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    Check failed
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p class="govuk-notification-banner__heading">There’s been a technical error.</p>
+                <p>@Html.ActionLink("Try again later", "Enter_Details", "Check"), ensuring you’ve entered the parent or guardian details accurately.</p>
+            </div>
+        </div>
 
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Check failed
-            </h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">There’s been a technical error.</p>
-            <p>@Html.ActionLink("Try again later", "Enter_Details", "Check"), ensuring you’ve entered the parent or guardian details accurately.</p>
-        </div>
+        <h1 class="govuk-heading-l">If the check keeps failing</h1>
+        <p>Contact the Department for Education support desk at ecs.admin@education.gov.uk.</p>
     </div>
-
-    <h1 class="govuk-heading-l">If the check keeps failing</h1>
-    <p>Contact the Department for Education support desk at ecs.admin@education.gov.uk.</p>
-
 </div>

--- a/CheckYourEligibility-Admin/Views/Check/Process_Appeals.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Process_Appeals.cshtml
@@ -2,6 +2,7 @@
 
 @{
     ViewData["Title"] = "Check Details";
+    ViewData["Layout"] = "full";
 }
 
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>

--- a/CheckYourEligibility-Admin/Views/Home/Accessibility.cshtml
+++ b/CheckYourEligibility-Admin/Views/Home/Accessibility.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     Layout = "~/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "Accessibility";
+    ViewData["Layout"] = "two_thirds";
 }
 
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>

--- a/CheckYourEligibility-Admin/Views/Home/Cookies.cshtml
+++ b/CheckYourEligibility-Admin/Views/Home/Cookies.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     Layout = "~/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "Cookies";
+    ViewData["Layout"] = "two_thirds";
 }
 
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>

--- a/CheckYourEligibility-Admin/Views/Home/Guidance.cshtml
+++ b/CheckYourEligibility-Admin/Views/Home/Guidance.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     Layout = "~/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "Guidance";
+    ViewData["Layout"] = "two_thirds";
 }
 
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>

--- a/CheckYourEligibility-Admin/Views/Home/Index.cshtml
+++ b/CheckYourEligibility-Admin/Views/Home/Index.cshtml
@@ -1,5 +1,6 @@
 ﻿@{
     ViewData["Title"] = "Check Details";
+    ViewData["Layout"] = "full";
 }
 
 @model CheckYourEligibility_DfeSignIn.Models.DfeClaims;

--- a/CheckYourEligibility-Admin/Views/Home/Privacy.cshtml
+++ b/CheckYourEligibility-Admin/Views/Home/Privacy.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     Layout = "~/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "Privacy policy";
+    ViewData["Layout"] = "two_thirds";
 }
 
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>

--- a/CheckYourEligibility-Admin/Views/Shared/_Layout.cshtml
+++ b/CheckYourEligibility-Admin/Views/Shared/_Layout.cshtml
@@ -8,7 +8,7 @@
 @{
     DfeClaims claims = DfeSignInExtensions.GetDfeClaims(_httpContext.HttpContext.User.Claims);
 
-    var clarityId = claims?.Organisation?.Category?.Name == Constants.CategoryTypeLA ? Configuration["Clarity:LA"] : Configuration["Clarity:School"] ;
+    var clarityId = claims?.Organisation?.Category?.Name == Constants.CategoryTypeLA ? Configuration["Clarity:LA"] : Configuration["Clarity:School"];
 }
 
 <!DOCTYPE html>
@@ -43,7 +43,7 @@
             <div class="dfe-header__content" id="content-header">
                 <ul class="dfe-header__action-links">
                     @* <li>
-                        <a href="#">My account</a>
+                    <a href="#">My account</a>
                     </li> *@
                     <li>
                         @Html.ActionLink("Sign out", "SignOut", "Account", null, new { @class = "signOut" })
@@ -75,7 +75,6 @@
         </div>
     </div>
 
-
     <div class="govuk-width-container ">
         <main class="govuk-main-wrapper " id="main-content" role="main">
             @if (ViewBag.Message != null)
@@ -93,10 +92,22 @@
                     </div>
                 </div>
             }
-            @RenderBody()
+            <div class="govuk-grid-row">
+                @if (ViewData["Layout"] != null && ViewData["Layout"].ToString() == "two_thirds")
+                {
+                    <div class="govuk-grid-column-two-thirds">
+                        @RenderBody()
+                    </div>
+                }
+                else //Default - ViewData["Layout"].ToString() == "full"
+                {
+                    <div class="govuk-grid-column-full">
+                        @RenderBody()
+                    </div>
+                }
+            </div>
         </main>
     </div>
-
 
     <footer class="govuk-footer " role="contentinfo">
         <div class="govuk-width-container ">
@@ -111,9 +122,9 @@
                         <li class="govuk-footer__inline-list-item">
                             <a class="govuk-footer__link" href="@Url.Action("Privacy", "Home")">Privacy policy</a>
                         </li>
-@* 
+                        @*
                         <li class="govuk-footer__inline-list-item">
-                            <a class="govuk-footer__link" href="@Url.Action("Accessibility", "Home")">Accessibility</a>
+                        <a class="govuk-footer__link" href="@Url.Action("Accessibility", "Home")">Accessibility</a>
                         </li> *@
 
                         <li class="govuk-footer__inline-list-item">

--- a/CheckYourEligibility-Parent/Views/Check/Application_Sent.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Application_Sent.cshtml
@@ -3,7 +3,7 @@
 
 @{
     ViewData["Title"] = "Application Sent";
-
+    ViewData["Layout"] = "full";
     var responseJson = TempData["FsmApplicationResponses"] as string;
     var responses = JsonConvert.DeserializeObject<List<CheckYourEligibility.Domain.Responses.ApplicationSaveItemResponse>>(responseJson);
 }
@@ -16,10 +16,15 @@
     ViewData["Title"] = "Application Sent";
     <partial name="_ValidationSummary" model="ViewData.ModelState" />
 }
-<div class="govuk-panel govuk-panel--confirmation">
-    <h1 class="govuk-panel__title">Application complete</h1>
-    <div class="govuk-panel__body">
-        Submitted on<br><strong>@responses[0].Data.Created.ToString("dd MMM yyyy")</strong>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+            <h1 class="govuk-panel__title">Application complete</h1>
+            <div class="govuk-panel__body">
+                Submitted on<br><strong>@responses[0].Data.Created.ToString("dd MMM yyyy")</strong>
+            </div>
+        </div>
     </div>
 </div>
 

--- a/CheckYourEligibility-Parent/Views/Check/Check_Answers.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Check_Answers.cshtml
@@ -3,7 +3,7 @@
 
 @{
     ViewData["Title"] = "Check Answers";
-
+    ViewData["Layout"] = "two_thirds";
     DateTime parentDOB = DateTime.ParseExact(Model.ParentDateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture);
     string formattedParentDOB = parentDOB.ToString("dd/MM/yyyy");
 }

--- a/CheckYourEligibility-Parent/Views/Check/Enter_Child_Details.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Enter_Child_Details.cshtml
@@ -2,6 +2,7 @@
 
 @{
     ViewData["Title"] = "Add details of your children";
+    ViewData["Layout"] = "two_thirds";
     var childIndex = TempData["childIndex"] as int?;
     var validationMessage = TempData["ValidationMessage"] as string;
  }

--- a/CheckYourEligibility-Parent/Views/Check/Enter_Details.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Enter_Details.cshtml
@@ -2,6 +2,7 @@
 
 @{
     ViewData["Title"] = "Check Details";
+    ViewData["Layout"] = "two_thirds";
 }
 
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>
@@ -96,8 +97,6 @@
 
         </fieldset>
     </div>
-
-
 
     <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="ni-number-hint">

--- a/CheckYourEligibility-Parent/Views/Check/Loader.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Loader.cshtml
@@ -1,35 +1,31 @@
 ﻿@{
     ViewData["Title"] = "Checking Loader";
+    ViewData["Layout"] = "full";
 }
 
-<!-- Meta Refresh Fallback (only triggered if JavaScript is disabled) -->
-<noscript>
-    <meta http-equiv="refresh" content="5;url=@Url.Action("Loader", "Check")" />
-</noscript>
+@* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a>*@
+<a class="govuk-back-link-nolink"></a>
 
-<div id="content" data-type="Loader">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="flex-container">
-                <div class="container">
-                    <h1 class="govuk-heading-l">
-                        Checking your entitlement
-                    </h1>
-                    <p class="govuk-body-l">Please wait. The check should take less than 30 seconds.</p>
-                    <div id="loader-spinner" class="spinner-container">
-                        <svg role="status" class="spinner animation-spin" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"></path>
-                            <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"></path>
-                        </svg>
-                    </div>
-                    <p class="govuk-body">
-                        We are processing your request. If this takes longer than 30 seconds, <a href="#">click here</a>.
-                    </p>
-                </div>
+<div class="govuk-grid-row" id="content" data-type="Loader" data-url="@Url.Action("Loader", "Check")">
+    <div class="govuk-grid-column-full">
+        <div class="flex-container">
+            <div class="container">
+                <h1 class="govuk-heading-l">
+                    Checking your entitlement
+                </h1>
+                <p class="govuk-body-l">Please wait. The check should take less than 30 seconds</p>
+                <svg role="status" class="spinner animation-spin" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"></path>
+                    <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"></path>
+                </svg>
+
             </div>
         </div>
     </div>
 </div>
 
-<!-- JavaScript for Polling the Status and Updating Only #content if Necessary -->
+<noscript>
+    <meta http-equiv="refresh" content="5;url=@Url.Action("Loader", "Check")" />
+</noscript>
+
 <script src="/js/eligibility-loader.js"></script>

--- a/CheckYourEligibility-Parent/Views/Check/Nass.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Nass.cshtml
@@ -4,7 +4,7 @@
 
 @{
     ViewData["Title"] = "Nass Number";
-
+    ViewData["Layout"] = "two_thirds";
     var request = TempData["ParentDetails"] as string;
     var parent = JsonConvert.DeserializeObject<Parent>(request);
 }

--- a/CheckYourEligibility-Parent/Views/Check/Outcome/Could_Not_Check.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Outcome/Could_Not_Check.cshtml
@@ -1,13 +1,15 @@
 ﻿@* <a class="govuk-back-link" href="/Back" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<div id="content" class="govuk-grid-column-full" data-type="Could_Not_Check">
-    <h1 class="govuk-heading-l">We could not check your children’s entitlement to free school meals</h1>
-    <p>You need to enter a National Insurance or asylum support reference number in order for the check to take place.</p>
-    <p><a href="https://www.gov.uk/lost-national-insurance-number?">How to find your National Insurance number</a></p>
-    <p>An asylum support reference number can usually be found on letters from the Home Office.</p>
-    <p>If you need more help, please contact your school administrator.</p>
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-two-thirds" data-type="Could_Not_Check">
+        <h1 class="govuk-heading-l">We could not check your children’s entitlement to free school meals</h1>
+        <p>You need to enter a National Insurance or asylum support reference number in order for the check to take place.</p>
+        <p><a href="https://www.gov.uk/lost-national-insurance-number?">How to find your National Insurance number</a></p>
+        <p>An asylum support reference number can usually be found on letters from the Home Office.</p>
+        <p>If you need more help, please contact your school administrator.</p>
 
 
-    <p><a href="../Check/Enter_Details">Try again</a></p>
+        <p><a href="../Check/Enter_Details">Try again</a></p>
+    </div>
 </div>

--- a/CheckYourEligibility-Parent/Views/Check/Outcome/Eligible.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Outcome/Eligible.cshtml
@@ -2,58 +2,58 @@
 
 <a class="govuk-back-link-nolink"></a>
 
-<div id="content" class="govuk-grid-column-full" data-type="Eligible">
-
-    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Children eligible
-            </h2>
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-two-thirds" data-type="Eligible">
+        <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    Children eligible
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <h3 class="govuk-notification-banner__heading">
+                    Your children are eligible for free school meals.
+                </h3>
+            </div>
         </div>
-        <div class="govuk-notification-banner__content">
-            <h3 class="govuk-notification-banner__heading">
-                Your children are eligible for free school meals.
-            </h3>
+
+        <h1 class="govuk-heading-l">Apply for free school meals for your children</h1>
+
+        <p>This usually takes a few minutes.</p>
+
+        <ol>
+            <li>Sign in or create a GOV.UK One Login.</li>
+            <li>Add the details of all your children and their schools.</li>
+            <li>Send your application to the school.</li>
+            <li>We'll send an application confirmation email to the email address used on your GOV.UK One Login.</li>
+            <li>Your children's school will arrange the free school meals.</li>
+        </ol>
+
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                    About GOV.UK One Login
+                </span>
+            </summary>
+            <div class="govuk-details__text">
+                GOV.UK One Login lets you sign in and prove your identity quickly and easily. You can use the same account for some other government services.
+            </div>
+        </details>
+
+        <div class="govuk-button-group">
+            <a href="@Model" class="govuk-button govuk-!-margin-top-5">Continue to GOV.UK One Login</a>
+            <a class="govuk-link" href="~/Home/Index"> Return to start now</a>
+        </div>
+
+        <hr class="govuk-section-break govuk-section-break govuk-section-break--m">
+
+        <h2 class="govuk-heading-m">Further guidance and other ways to apply</h2>
+        <p>If you need further support, <a target="_blank" href="/Home/Parental_Guidance">check the more detailed guidance</a>  for parents and guardians.</p>
+        <p>If you cannot apply online, you can fill in <a href="@Url.Action("fsm_print_version", "Home")">the 'Free school meals entitlement checker' form</a> and give it to your children's school. </p>
+
+
+        <div class="govuk-inset-text">
+            It takes longer to apply through your school than it does online.
         </div>
     </div>
-
-    <h1 class="govuk-heading-l">Apply for free school meals for your children</h1>
-
-    <p>This usually takes a few minutes.</p>
-
-    <ol>
-        <li>Sign in or create a GOV.UK One Login.</li>
-        <li>Add the details of all your children and their schools.</li>
-        <li>Send your application to the school.</li>
-        <li>We'll send an application confirmation email to the email address used on your GOV.UK One Login.</li>
-        <li>Your children's school will arrange the free school meals.</li>
-    </ol>
-
-    <details class="govuk-details">
-        <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-                About GOV.UK One Login
-            </span>
-        </summary>
-        <div class="govuk-details__text">
-            GOV.UK One Login lets you sign in and prove your identity quickly and easily. You can use the same account for some other government services.
-        </div>
-    </details>
-
-    <div class="govuk-button-group">
-        <a href="@Model" class="govuk-button govuk-!-margin-top-5">Continue to GOV.UK One Login</a>
-        <a class="govuk-link" href="~/Home/Index"> Return to start now</a>
-    </div>
-
-    <hr class="govuk-section-break govuk-section-break govuk-section-break--m">
-
-    <h2 class="govuk-heading-m">Further guidance and other ways to apply</h2>
-    <p>If you need further support, <a target="_blank" href="/Home/Parental_Guidance">check the more detailed guidance</a>  for parents and guardians.</p>
-    <p>If you cannot apply online, you can fill in <a href="@Url.Action("fsm_print_version", "Home")">the 'Free school meals entitlement checker' form</a> and give it to your children's school. </p>
-
-
-    <div class="govuk-inset-text">
-        It takes longer to apply through your school than it does online.
-    </div>
-
 </div>

--- a/CheckYourEligibility-Parent/Views/Check/Outcome/Not_Eligible.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Outcome/Not_Eligible.cshtml
@@ -1,63 +1,63 @@
 ﻿@* <a class="govuk-back-link" href="/Back" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<div id="content" class="govuk-grid-column-full" data-type="Not_Eligible">
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-two-thirds" data-type="Not_Eligible">
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    May not be eligible
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p class="govuk-notification-banner__heading">
+                    Your children may not be eligible for free school meals.
+                </p>
+                <p class="govuk-body">From the information you’ve provided, we cannot confirm if your children are eligible for free school meals.</p>
+            </div>
+        </div>
 
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                May not be eligible
-            </h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">
-                Your children may not be eligible for free school meals.
-            </p>
-            <p class="govuk-body">From the information you’ve provided, we cannot confirm if your children are eligible for free school meals.</p>
-        </div>
+        <h1 class="govuk-heading-l">If you think your children are eligible</h1>
+        <p>If you think that they are eligible, you'll need to find supporting evidence.</p>
+
+        <ol>
+            <li>Find supporting evidence.</li>
+            <li>Contact your childrens school(s) and send them the evidence.</li>
+            <li>The school(s) will work with your local authority to review your free school meal eligibility, then let you know the result.</li>
+        </ol>
+
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                    Complete list of acceptable evidence
+                </span>
+            </summary>
+            <div class="govuk-details__text">
+                <p>To support your claim for free school meals, you can send:</p>
+                <ul>
+                    <li>up to three of your latest Universal Credit statements </li>
+                    <li>
+                        your latest tax credit statement form TC602A (Award Notices) or TC603R (Auto Renewal), showing you are receiving Working Tax Credit run-on
+                    </li>
+                    <li>
+                        your latest tax credit statement form TC602A (Award Notices) or TC603R (Auto Renewal), showing you are receiving Child Tax Credit
+                    </li>
+                    <li>
+                        a letter of Entitlement for Income Support
+                    </li>
+                    <li>
+                        a letter of Entitlement for income-based Jobseeker’s Allowance
+                    </li>
+                    <li>
+                        a letter of Entitlement for the guaranteed element of Pension Credit
+                    </li>
+                    <li>documents showing you are receiving relevant support under part VI of the Immigration and Asylum Act 1999 </li>
+                </ul>
+            </div>
+        </details>
+
+        <h2 class="govuk-heading-m">Further guidance</h2>
+        <p>More in-depth information on supporting evidence can be found in <a href="/Home/Parental_Guidance" class="govuk-link">the guidance notes for parents and guardians.</a></p>
+        <p><a href="/Home/Index">Return to start</a></p>
     </div>
-
-    <h1 class="govuk-heading-l">If you think your children are eligible</h1>
-    <p>If you think that they are eligible, you'll need to find supporting evidence.</p>
-
-    <ol>
-        <li>Find supporting evidence.</li>
-        <li>Contact your childrens school(s) and send them the evidence.</li>
-        <li>The school(s) will work with your local authority to review your free school meal eligibility, then let you know the result.</li>
-    </ol>
-
-    <details class="govuk-details">
-        <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-                Complete list of acceptable evidence
-            </span>
-        </summary>
-        <div class="govuk-details__text">
-            <p>To support your claim for free school meals, you can send:</p>
-            <ul>
-                <li>up to three of your latest Universal Credit statements </li>
-                <li>
-                    your latest tax credit statement form TC602A (Award Notices) or TC603R (Auto Renewal), showing you are receiving Working Tax Credit run-on
-                </li>
-                <li>
-                    your latest tax credit statement form TC602A (Award Notices) or TC603R (Auto Renewal), showing you are receiving Child Tax Credit
-                </li>
-                <li>
-                    a letter of Entitlement for Income Support
-                </li>
-                <li>
-                    a letter of Entitlement for income-based Jobseeker’s Allowance
-                </li>
-                <li>
-                    a letter of Entitlement for the guaranteed element of Pension Credit
-                </li>
-                <li>documents showing you are receiving relevant support under part VI of the Immigration and Asylum Act 1999 </li>
-            </ul>
-        </div>
-    </details>
-
-    <h2 class="govuk-heading-m">Further guidance</h2>
-    <p>More in-depth information on supporting evidence can be found in <a href="/Home/Parental_Guidance" class="govuk-link">the guidance notes for parents and guardians.</a></p>
-    <p><a href="/Home/Index">Return to start</a></p>
-
 </div>

--- a/CheckYourEligibility-Parent/Views/Check/Outcome/Not_Found.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Outcome/Not_Found.cshtml
@@ -1,21 +1,21 @@
 ﻿@* <a class="govuk-back-link" href="/Back" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<div id="content" class="govuk-grid-column-full" data-type="Not_Found">
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-two-thirds" data-type="Not_Found">
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    Check failed
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p class="govuk-notification-banner__heading">The personal information you entered does not match departmental records.</p>
+            </div>
+        </div>
 
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">  
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Check failed
-            </h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">The personal information you entered does not match departmental records.</p>
-        </div>
+        <h1 class="govuk-heading-l">Check your details and try again</h1>
+        <p class="govuk-body"><a href="~/Check/Enter_Details">Try again</a>, ensuring you’ve entered your details accurately.</p>
+        <p class="govuk-body">If the check keeps failing, contact your school administrator.</p>
     </div>
-
-    <h1 class="govuk-heading-l">Check your details and try again</h1>
-    <p class="govuk-body"><a href="~/Check/Enter_Details">Try again</a>, ensuring you’ve entered your details accurately.</p>
-    <p class="govuk-body">If the check keeps failing, contact your school administrator.</p>
-
 </div>

--- a/CheckYourEligibility-Parent/Views/Check/Outcome/Not_Found_Pending.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Outcome/Not_Found_Pending.cshtml
@@ -1,34 +1,35 @@
 ﻿@* <a class="govuk-back-link" href="/Back" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<div id="content" class="govuk-grid-column-full" data-type="Not_Found_Pending">
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-two-thirds" data-type="Not_Found_Pending">
 
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Check failed
-            </h2>
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    Check failed
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p class="govuk-notification-banner__heading">Universal Credit statements needed to perform the check may not be currently available.</p>
+
+            </div>
         </div>
-        <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">Universal Credit statements needed to perform the check may not be currently available.</p>
 
+        <h1 class="govuk-heading-l">Find your Universal Credit statements</h1>
+        <p>If you have up-to-date Universal Credit statements as supporting evidence, show these to your school’s administrator. </p>
+
+        <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+                <span class="govuk-visually-hidden">Warning</span>
+                Your annual net earned income must be no higher than £7,400 and any documents you provide must show your income and the date.
+            </strong>
         </div>
+
+        <p>If you are an asylum seeker, check to see what asylum support is available. </p>
+        <h2 class="govuk-heading-m">Further guidance </h2>
+        <p>More in-depth information on supporting evidence can be found in the  <a target="_blank" href="../checker/parent-guidance.html">guidance notes for parents and guardians. </a></p><a target="_blank" href="../checker/parent-guidance.html"></a>
+        <p><a target="_blank" href="../checker/parent-guidance.html"></a><a <a href="~/Check/Enter_Details">Try again</a></p>
     </div>
-
-    <h1 class="govuk-heading-l">Find your Universal Credit statements</h1>
-    <p>If you have up-to-date Universal Credit statements as supporting evidence, show these to your school’s administrator. </p>
-
-    <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-            <span class="govuk-visually-hidden">Warning</span>
-            Your annual net earned income must be no higher than £7,400 and any documents you provide must show your income and the date.
-        </strong>
-    </div>
-
-    <p>If you are an asylum seeker, check to see what asylum support is available. </p>
-    <h2 class="govuk-heading-m">Further guidance </h2>
-    <p>More in-depth information on supporting evidence can be found in the  <a target="_blank" href="../checker/parent-guidance.html">guidance notes for parents and guardians. </a></p><a target="_blank" href="../checker/parent-guidance.html"></a>
-    <p><a target="_blank" href="../checker/parent-guidance.html"></a><a <a href="~/Check/Enter_Details">Try again</a></p>
-
 </div>

--- a/CheckYourEligibility-Parent/Views/Check/Outcome/Technical_Error.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Outcome/Technical_Error.cshtml
@@ -3,21 +3,22 @@
 @* <a class="govuk-back-link" href="/Back" onclick="history.back(); return false;">Back</a> *@
 <a class="govuk-back-link-nolink"></a>
 
-<div id="content" class="govuk-grid-column-full" data-type="Technical_Error">
+<div class="govuk-grid-row">
+    <div id="content" class="govuk-grid-column-two-thirds" data-type="Technical_Error">
 
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Check failed
-            </h2>
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    Check failed
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p class="govuk-notification-banner__heading">There’s been a technical error.</p>
+                <p><a href="~/Check/Enter_Details">Try again</a>, ensuring you’ve entered your details accurately.</p>
+            </div>
         </div>
-        <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">There’s been a technical error.</p>
-            <p><a href="~/Check/Enter_Details">Try again</a>, ensuring you’ve entered your details accurately.</p>
-        </div>
+
+        <h1 class="govuk-heading-l">If the check keeps failing</h1>
+        <p>Contact your school administrator.</p>
     </div>
-
-    <h1 class="govuk-heading-l">If the check keeps failing</h1>
-    <p>Contact your school administrator.</p>
-
 </div>

--- a/CheckYourEligibility-Parent/Views/Home/Accessibility.cshtml
+++ b/CheckYourEligibility-Parent/Views/Home/Accessibility.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     Layout = "~/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "Accessibility";
+    ViewData["Layout"] = "two_thirds";
 }
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>
 @* <a class="govuk-back-link-nolink"></a> *@

--- a/CheckYourEligibility-Parent/Views/Home/Cookies.cshtml
+++ b/CheckYourEligibility-Parent/Views/Home/Cookies.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     Layout = "~/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "Cookies";
+    ViewData["Layout"] = "two_thirds";
 }
 
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>

--- a/CheckYourEligibility-Parent/Views/Home/Parental_Guidance.cshtml
+++ b/CheckYourEligibility-Parent/Views/Home/Parental_Guidance.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     Layout = "~/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "Parental Guidance";
+    ViewData["Layout"] = "two_thirds";
 }
 
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>

--- a/CheckYourEligibility-Parent/Views/Home/Privacy.cshtml
+++ b/CheckYourEligibility-Parent/Views/Home/Privacy.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     Layout = "~/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "Privacy Policy";
+    ViewData["Layout"] = "two_thirds";
 }
 
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>

--- a/CheckYourEligibility-Parent/Views/Home/fsm_print_version.cshtml
+++ b/CheckYourEligibility-Parent/Views/Home/fsm_print_version.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     Layout = "~/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "FSM Print Version";
+    ViewData["Layout"] = "two_thirds";
 }
 
 <a class="govuk-back-link" href="@Url.Action("Index", "Home")" onclick="history.back(); return false;">Back</a>

--- a/CheckYourEligibility-Parent/Views/Shared/_Layout.cshtml
+++ b/CheckYourEligibility-Parent/Views/Shared/_Layout.cshtml
@@ -60,19 +60,39 @@
         </div>
     </div>
 
-
-    <main role="main">
-        <div class="govuk-width-container ">
-            <main class="govuk-main-wrapper " id="main-content" role="main">
-                <div class="govuk-grid-row">
+    <div class="govuk-width-container ">
+        <main class="govuk-main-wrapper " id="main-content" role="main">
+            @if (ViewBag.Message != null)
+            {
+                <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+                    <div class="govuk-notification-banner__header">
+                        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                            Notice
+                        </h2>
+                    </div>
+                    <div class="govuk-notification-banner__content">
+                        <p class="govuk-notification-banner__heading">
+                            @ViewBag.Message
+                        </p>
+                    </div>
+                </div>
+            }
+            <div class="govuk-grid-row">
+                @if (ViewData["Layout"] != null && ViewData["Layout"].ToString() == "two_thirds")
+                {
                     <div class="govuk-grid-column-two-thirds">
                         @RenderBody()
                     </div>
-                </div>
-            </main>
-        </div>
-    </main>
-
+                }
+                else //Default - ViewData["Layout"].ToString() == "full"
+                {
+                    <div class="govuk-grid-column-full">
+                        @RenderBody()
+                    </div>
+                }
+            </div>
+        </main>
+    </div>
 
     <footer class="govuk-footer " role="contentinfo">
         <div class="govuk-width-container ">
@@ -87,9 +107,9 @@
                         <li class="govuk-footer__inline-list-item">
                             <a class="govuk-footer__link" href="@Url.Action("Privacy", "Home")">Privacy policy</a>
                         </li>
-@* 
+                        @*
                         <li class="govuk-footer__inline-list-item">
-                            <a class="govuk-footer__link" href="@Url.Action("Accessibility", "Home")">Accessibility</a>
+                        <a class="govuk-footer__link" href="@Url.Action("Accessibility", "Home")">Accessibility</a>
                         </li> *@
 
                         <li class="govuk-footer__inline-list-item">


### PR DESCRIPTION
QA Note: Parent Journey

When implementing this fix it became clear that we needed a more comprehensive way to manage the layout of views across all journeys. There are two main widths currently in use across the system: two-thirds, and full.

In general we would use two-thirds for forms and general content. For tabular data such as search results we would use full to gain the extra width on the screen to fit more content. The bug in this ticket is with the loader page which should be full width.

The code has been refactored in the layout so that the view can pass a parameter detailing which view to use and then the appropriate width is used for that page when it is rendered. Doing this meant adding the new code to the Layout and the parameter to each view. The method is that if the parameter is "two_thirds" then it uses that width else it uses full. So, for example, if a page didn't send a value the default would be full width.

I have designated the majority of pages in the application as two thirds based off the content in the prototype so you can presume all pages have been updated in this way. Listed below are all the pages that I set as full width so that QA have a reference of the ones that should look different.

- Loader.cshtml
- Application_Sent.cshtml

Due to the Loader page becoming full width and the outcome pages being injected into the loader page container to display them, and them all being two-thirds width, all outcomes have also been edited and should be tested to ensure they show as two-thirds as the layout width for them is specified within the view itself.

- Could_Not_Check.cshtml
- Eligible.cshtml
- Not_Eligible.cshtml
- Not_Found.cshtml
- Not_Found_Pending.cshtml
- Technical_Error.cshtml

QA Note: Parent Journey

Pages designated as full-width but for School/LA Journey:

- Process_Appeals.cshtml
- Loader.cshtml (added parameter but display's as before)
- Check_Answers.cshtml
- ApplicationsRegistered.cshtml
- AppealsApplications.cshtml
- ApplicationDetail.cshtml
- ApplicationDetailAppeal.cshtml
- ApplicationDetailFinalise.cshtml
- ApplicationDetailLa.cshtml
- FinaliseApplications.cshtml
- PendingApplications.cshtml
- Search.cshtml
- SearchResults.cshtml

​As with the Parent journey the outcomes for School and LA have been updated. (Remember that Eligible and Not_Eligible are separate pages for LA journey).

- Eligible.cshtml
- Eligible_LA.cshtml
- Not_Eligible.cshtml
- Not_Eligible_LA.cshtml
- Not_Found.cshtml
- `Technical_Error.cshtml