### PR TITLE
Bugfix: Remove id=content from outcome pages

### DIFF
--- a/CheckYourEligibility-Admin/Views/BulkCheck/BulkOutcome/Error_Data_Issue.cshtml
+++ b/CheckYourEligibility-Admin/Views/BulkCheck/BulkOutcome/Error_Data_Issue.cshtml
@@ -2,7 +2,7 @@
     ViewData["Title"] = "Could not check eligibility";
 }
 
-<div id="content" data-type="ErrorData">
+<div data-type="ErrorData">
     <a class="govuk-back-link-nolink"></a>
 
     <div class="govuk-error-summary govuk-grid-column-full" data-module="govuk-error-summary">

--- a/CheckYourEligibility-Admin/Views/BulkCheck/BulkOutcome/Error_Not_Accepted.cshtml
+++ b/CheckYourEligibility-Admin/Views/BulkCheck/BulkOutcome/Error_Not_Accepted.cshtml
@@ -2,10 +2,10 @@
     ViewData["Title"] = "Could not check eligibility";
 }
 
-<div id="content" data-type="ErrorNotAccepted">
+<div data-type="ErrorNotAccepted">
     <a class="govuk-back-link-nolink"></a>
 
-    <div class="govuk-error-summary govuk-grid-column-full" data-module="govuk-error-summary" id="content" data-type="success">
+    <div class="govuk-error-summary govuk-grid-column-full" data-module="govuk-error-summary" data-type="success">
         <div role="alert">
             <h2 class="govuk-error-summary__title">
                 Error – File not accepted

--- a/CheckYourEligibility-Admin/Views/BulkCheck/BulkOutcome/Success.cshtml
+++ b/CheckYourEligibility-Admin/Views/BulkCheck/BulkOutcome/Success.cshtml
@@ -2,7 +2,7 @@
 <a class="govuk-back-link-nolink"></a>
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-full" data-type="success">
+    <div class="govuk-grid-column-full" data-type="success">
 
         <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
             <div class="govuk-notification-banner__header">

--- a/CheckYourEligibility-Admin/Views/Check/Outcome/Eligible.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Outcome/Eligible.cshtml
@@ -2,7 +2,7 @@
 @* <a class="govuk-back-link-nolink"></a> *@
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-two-thirds" data-type="Eligible">
+    <div class="govuk-grid-column-two-thirds" data-type="Eligible">
         <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/CheckYourEligibility-Admin/Views/Check/Outcome/Eligible_LA.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Outcome/Eligible_LA.cshtml
@@ -2,7 +2,7 @@
 <a class="govuk-back-link-nolink"></a>
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-two-thirds" data-type="Eligible_LA">
+    <div class="govuk-grid-column-two-thirds" data-type="Eligible_LA">
         <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/CheckYourEligibility-Admin/Views/Check/Outcome/Not_Eligible.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Outcome/Not_Eligible.cshtml
@@ -3,7 +3,7 @@
 @* <a class="govuk-back-link-nolink"></a> *@
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-two-thirds" data-type="Not_Eligible">
+    <div class="govuk-grid-column-two-thirds" data-type="Not_Eligible">
         <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/CheckYourEligibility-Admin/Views/Check/Outcome/Not_Eligible_LA.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Outcome/Not_Eligible_LA.cshtml
@@ -3,7 +3,7 @@
 <a class="govuk-back-link-nolink"></a>
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-two-thirds" data-type="Not_Eligible_LA">
+    <div class="govuk-grid-column-two-thirds" data-type="Not_Eligible_LA">
         <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/CheckYourEligibility-Admin/Views/Check/Outcome/Not_Found.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Outcome/Not_Found.cshtml
@@ -2,7 +2,7 @@
 <a class="govuk-back-link-nolink"></a>
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-two-thirds" data-type="Not_Found">
+    <div class="govuk-grid-column-two-thirds" data-type="Not_Found">
         <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/CheckYourEligibility-Admin/Views/Check/Outcome/Technical_Error.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Outcome/Technical_Error.cshtml
@@ -3,7 +3,7 @@
 @* <a class="govuk-back-link-nolink"></a> *@
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-two-thirds" data-type="Technical_Error">
+    <div class="govuk-grid-column-two-thirds" data-type="Technical_Error">
         <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/CheckYourEligibility-Parent/Views/Check/Outcome/Could_Not_Check.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Outcome/Could_Not_Check.cshtml
@@ -2,7 +2,7 @@
 <a class="govuk-back-link-nolink"></a>
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-two-thirds" data-type="Could_Not_Check">
+    <div class="govuk-grid-column-two-thirds" data-type="Could_Not_Check">
         <h1 class="govuk-heading-l">We could not check your children’s entitlement to free school meals</h1>
         <p>You need to enter a National Insurance or asylum support reference number in order for the check to take place.</p>
         <p><a href="https://www.gov.uk/lost-national-insurance-number?">How to find your National Insurance number</a></p>

--- a/CheckYourEligibility-Parent/Views/Check/Outcome/Eligible.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Outcome/Eligible.cshtml
@@ -3,7 +3,7 @@
 <a class="govuk-back-link-nolink"></a>
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-two-thirds" data-type="Eligible">
+    <div class="govuk-grid-column-two-thirds" data-type="Eligible">
         <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/CheckYourEligibility-Parent/Views/Check/Outcome/Not_Eligible.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Outcome/Not_Eligible.cshtml
@@ -2,7 +2,7 @@
 <a class="govuk-back-link-nolink"></a>
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-two-thirds" data-type="Not_Eligible">
+    <div class="govuk-grid-column-two-thirds" data-type="Not_Eligible">
         <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/CheckYourEligibility-Parent/Views/Check/Outcome/Not_Found.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Outcome/Not_Found.cshtml
@@ -2,7 +2,7 @@
 <a class="govuk-back-link-nolink"></a>
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-two-thirds" data-type="Not_Found">
+    <div class="govuk-grid-column-two-thirds" data-type="Not_Found">
         <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/CheckYourEligibility-Parent/Views/Check/Outcome/Not_Found_Pending.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Outcome/Not_Found_Pending.cshtml
@@ -2,8 +2,7 @@
 <a class="govuk-back-link-nolink"></a>
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-two-thirds" data-type="Not_Found_Pending">
-
+    <div class="govuk-grid-column-two-thirds" data-type="Not_Found_Pending">
         <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/CheckYourEligibility-Parent/Views/Check/Outcome/Technical_Error.cshtml
+++ b/CheckYourEligibility-Parent/Views/Check/Outcome/Technical_Error.cshtml
@@ -4,7 +4,7 @@
 <a class="govuk-back-link-nolink"></a>
 
 <div class="govuk-grid-row">
-    <div id="content" class="govuk-grid-column-two-thirds" data-type="Technical_Error">
+    <div class="govuk-grid-column-two-thirds" data-type="Technical_Error">
 
         <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
             <div class="govuk-notification-banner__header">


### PR DESCRIPTION
https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_workitems/edit/193801

Background. Noticed that the layout of the loader page and the outcome content both had 'id="content"' and as such, because id's a unique the page could only display one. Result of this is that the loader id would be written to the DOM and then when the outcome tried to add to the DOM the header with the ID would cause an error and the class for dictating the page width of two thirds would not be added. If the page was subsequently reloaded it would take the ID from the outcome rather than the loader. I think this is why it got through QA the first time round, because of the way we test the content it looked like it was correct sometimes.

For QA: Just ensure that the two thirds width is shown during normal execution of the page where the loader functions, ie, not a cached page. Perform a check with a new customer's details and if necessary override the outcome in code. That said it may be harder to QA from a published release. All outcomes use the same methodology to handle the layout so if you can check at least one or two the rest should operate the same. Devs can confirm the code matches on all outcomes.