### PR TITLE
Update to incorrect title on landing page and add a missing character…

### DIFF
--- a/CheckYourEligibility-Parent/Views/Home/Index.cshtml
+++ b/CheckYourEligibility-Parent/Views/Home/Index.cshtml
@@ -3,7 +3,7 @@
 @using Microsoft.AspNetCore.Http.Extensions
 @{
     Layout = "~/Views/Shared/_Layout_StartNow.cshtml";
-    ViewData["Title"] = "Dashboard";
+    ViewData["Title"] = "Check if your children can get free school meals";
     // var url = UriHelper.GetDisplayUrl(HttpContextAccessor.HttpContext.Request);
     // url = url.Replace("as", "as-admin");
 }
@@ -12,9 +12,7 @@
     <main class="govuk-main-wrapper " id="main-content" role="main">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                <h1 class="govuk-heading-xl">
-                    Check if your children can get free school meals
-                </h1>
+                <h1 class="govuk-heading-xl">@ViewData["Title"]</h1>
             </div>
         </div>
         <div class="govuk-grid-row">

--- a/CheckYourEligibility-Parent/Views/Shared/_Layout_StartNow.cshtml
+++ b/CheckYourEligibility-Parent/Views/Shared/_Layout_StartNow.cshtml
@@ -5,7 +5,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>@ViewData["Title"] Check and apply for school and childcare support - GOV.UK</title>
+    <title>@ViewData["Title"] - Check and apply for school and childcare support - GOV.UK</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link href="~/css/govuk-frontend.min.css" rel="stylesheet" />
     <link href="~/css/application.css" rel="stylesheet" />


### PR DESCRIPTION
Fix to issue picked up in sign off session for this bug.

Update to incorrect title in tab header on landing page (index) and add a missing character to govuk layout (layout_startnow).

Bug: https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_workitems/edit/194928