### PR TITLE
Parent - Cookies banner and cookies page consent options

### DIFF
--- a/CheckYourEligibility-Parent/Views/Home/Cookies.cshtml
+++ b/CheckYourEligibility-Parent/Views/Home/Cookies.cshtml
@@ -233,4 +233,36 @@
             </table>
         </div>
     </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h2 class="govuk-heading-l">Change your cookie settings</h2>
+            <form id="cookie-form" action="/form-handler" method="post" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                            Do you want to accept analytics cookies?
+                        </legend>
+                        <div class="govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies[analytics]" type="radio" value="yes">
+                                <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
+                                    Yes
+                                </label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies[analytics]" type="radio" value="no" checked>
+                                <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
+                                    No
+                                </label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">
+                    Save cookie settings
+                </button>
+            </form>
+        </div>
+    </div>
 </div>

--- a/CheckYourEligibility-Parent/Views/Shared/_Layout.cshtml
+++ b/CheckYourEligibility-Parent/Views/Shared/_Layout.cshtml
@@ -16,24 +16,29 @@
 </head>
 
 <body class="govuk-template__body" data-clarity="@Configuration["Clarity:Parent"]">
-    <div id="cookie-banner" class="govuk-cookie-banner cookie-hidden" role="region" aria-label="Cookies on Check a family's eligibility" data-nosnippet>
+
+    <div id="cookie-banner" class="govuk-cookie-banner" data-nosnippet="" role="region" aria-label="Cookies on Check a family's eligibility">
         <div class="govuk-cookie-banner__message govuk-width-container">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on check a family's eligibility</h2>
                     <div class="govuk-cookie-banner__content">
-                        <p class="govuk-body">We use some essential cookies to make this website work.</p>
-                        <p class="govuk-body">We'd like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+                        <p class="govuk-body">We use some essential cookies to make this service work.</p>
+                        <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
                     </div>
                 </div>
             </div>
 
-            <button class="govuk-button" type="button" id="accept-cookies" data-module="govuk-button">
-                Accept analytics cookies
-            </button>
-            <button class="govuk-button govuk-button--secondary" type="button" id="reject-cookies" data-module="govuk-button">
-                Reject analytics cookies
-            </button>
+            <div class="govuk-button-group">
+                <button type="button" class="govuk-button" id="accept-cookies" data-module="govuk-button" data-govuk-button-init="">
+                    Accept analytics cookies
+                </button>
+                <button type="button" class="govuk-button" id="reject-cookies" data-module="govuk-button" data-govuk-button-init="">
+                    Reject analytics cookies
+                </button>
+                <a class="govuk-link" href="Home/Cookies">View cookies</a>
+            </div>
+
         </div>
     </div>
     <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
@@ -155,7 +160,7 @@
     <script src="~/js/dfefrontend.js"></script>
 
 
-    <script type="module" src="~/js/javascript-starter.js"></script>
+    <script type="module" src="~/js/cookieFunctions.js"></script>
 
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/CheckYourEligibility-Parent/Views/Shared/_Layout.cshtml
+++ b/CheckYourEligibility-Parent/Views/Shared/_Layout.cshtml
@@ -17,7 +17,7 @@
 
 <body class="govuk-template__body" data-clarity="@Configuration["Clarity:Parent"]">
 
-    <div id="cookie-banner" class="govuk-cookie-banner" data-nosnippet="" role="region" aria-label="Cookies on Check a family's eligibility">
+    <div id="cookie-banner" class="govuk-cookie-banner cookie-hidden" data-nosnippet="" role="region" aria-label="Cookies on Check a family's eligibility">
         <div class="govuk-cookie-banner__message govuk-width-container">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">

--- a/CheckYourEligibility-Parent/Views/Shared/_Layout.cshtml
+++ b/CheckYourEligibility-Parent/Views/Shared/_Layout.cshtml
@@ -36,9 +36,8 @@
                 <button type="button" class="govuk-button" id="reject-cookies" data-module="govuk-button" data-govuk-button-init="">
                     Reject analytics cookies
                 </button>
-                <a class="govuk-link" href="Home/Cookies">View cookies</a>
+                <a class="govuk-link" href="/Home/Cookies">View cookies</a>
             </div>
-
         </div>
     </div>
     <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>

--- a/CheckYourEligibility-Parent/Views/Shared/_Layout_StartNow.cshtml
+++ b/CheckYourEligibility-Parent/Views/Shared/_Layout_StartNow.cshtml
@@ -12,24 +12,28 @@
 </head>
 
 <body class="govuk-template__body js-enabled" data-clarity="@Configuration["Clarity:Parent"]">
-    <div id="cookie-banner" class="govuk-cookie-banner cookie-hidden" role="region" aria-label="Cookies on Check a family's eligibility" data-nosnippet>
+    <div id="cookie-banner" class="govuk-cookie-banner" data-nosnippet="" role="region" aria-label="Cookies on Check a family's eligibility">
         <div class="govuk-cookie-banner__message govuk-width-container">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on check a family's eligibility</h2>
                     <div class="govuk-cookie-banner__content">
-                        <p class="govuk-body">We use some essential cookies to make this website work.</p>
-                        <p class="govuk-body">We'd like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+                        <p class="govuk-body">We use some essential cookies to make this service work.</p>
+                        <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
                     </div>
                 </div>
             </div>
 
-            <button class="govuk-button" type="button" id="accept-cookies" data-module="govuk-button">
-                Accept analytics cookies
-            </button>
-            <button class="govuk-button govuk-button--secondary" type="button" id="reject-cookies" data-module="govuk-button">
-                Reject analytics cookies
-            </button>
+            <div class="govuk-button-group">
+                <button type="button" class="govuk-button" id="accept-cookies" data-module="govuk-button" data-govuk-button-init="">
+                    Accept analytics cookies
+                </button>
+                <button type="button" class="govuk-button" id="reject-cookies" data-module="govuk-button" data-govuk-button-init="">
+                    Reject analytics cookies
+                </button>
+                <a class="govuk-link" href="Home/Cookies">View cookies</a>
+            </div>
+
         </div>
     </div>
     <header class="govuk-header " role="banner" data-module="govuk-header">
@@ -113,7 +117,7 @@
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script type="module" src="~/js/govuk-frontend.min.js"></script>
-    <script type="module" src="~/js/javascript-starter.js"></script>
+    <script type="module" src="~/js/cookieFunctions.js"></script>
 </body>
 </html>
 

--- a/CheckYourEligibility-Parent/Views/Shared/_Layout_StartNow.cshtml
+++ b/CheckYourEligibility-Parent/Views/Shared/_Layout_StartNow.cshtml
@@ -31,9 +31,8 @@
                 <button type="button" class="govuk-button" id="reject-cookies" data-module="govuk-button" data-govuk-button-init="">
                     Reject analytics cookies
                 </button>
-                <a class="govuk-link" href="Home/Cookies">View cookies</a>
+                <a class="govuk-link" href="/Home/Cookies">View cookies</a>
             </div>
-
         </div>
     </div>
     <header class="govuk-header " role="banner" data-module="govuk-header">

--- a/CheckYourEligibility-Parent/wwwroot/js/cookieFunctions.js
+++ b/CheckYourEligibility-Parent/wwwroot/js/cookieFunctions.js
@@ -20,27 +20,54 @@ function initializeClarity() {
 }
 
 function initCookieConsent() {
+    console.log("in innitCookieConsent");
     const hasChoice = cookie.read("cookie");
-    if (hasChoice==="true") {
+    if (hasChoice !== null) {
         initializeClarity();
-    }
-    
-    else if (hasChoice !== "false") {
+        document.getElementById('cookie-banner').style.display = 'none';
+        console.log("in innitCookieConsent - hasChoice not equal null");
+
+    } else {
         document.getElementById('cookie-banner').style.display = 'block';
+        console.log("in innitCookieConsent - hasChoice else");
     }
-    
-    console.log(hasChoice);
 }
 
-document.getElementById('accept-cookies').onclick = function() {
+document.getElementById('accept-cookies').onclick = function () {
     cookie.create("cookie", "true", 365);
     document.getElementById('cookie-banner').style.display = 'none';
     initializeClarity();
 };
-document.getElementById('reject-cookies').onclick = function() {
+document.getElementById('reject-cookies').onclick = function () {
     cookie.create("cookie", "false", 365);
     document.getElementById('cookie-banner').style.display = 'none';
 };
+
+document.addEventListener('DOMContentLoaded', function () {
+    const cookieForm = document.getElementById('cookie-form');
+    if (cookieForm) {
+
+        const hasChoice = cookie.read("cookie");
+        if (hasChoice === "true") {
+            document.getElementById('cookies-analytics-yes').checked = true;
+        } else if (hasChoice === "false") {
+            document.getElementById('cookies-analytics-no').checked = true;
+        }
+
+        cookieForm.addEventListener('submit', function (event) {
+            event.preventDefault();
+            const analyticsCookies = document.querySelector('input[name="cookies[analytics]"]:checked').value;
+            if (analyticsCookies) {
+                cookie.create("cookie", "true", 365);
+                initializeClarity();
+
+            } else {
+                cookie.create("cookie", "false", 365);
+            }
+            document.getElementById('cookie-banner').style.display = 'none';
+        });
+    }
+});
 
 var cookie = {
     create: function (name, value, days) {

--- a/CheckYourEligibility-Parent/wwwroot/js/cookieFunctions.js
+++ b/CheckYourEligibility-Parent/wwwroot/js/cookieFunctions.js
@@ -3,6 +3,8 @@ document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prot
 import { initAll } from './govuk-frontend.min.js'
 initAll();
 
+const cookieForm = document.getElementById('cookie-form');
+
 function initializeClarity() {
     let clarityId = document.getElementsByTagName("body")[0].getAttribute("data-clarity");
     if (clarityId) {
@@ -20,16 +22,21 @@ function initializeClarity() {
 }
 
 function initCookieConsent() {
-    console.log("in innitCookieConsent");
     const hasChoice = cookie.read("cookie");
     if (hasChoice !== null) {
-        initializeClarity();
         document.getElementById('cookie-banner').style.display = 'none';
-        console.log("in innitCookieConsent - hasChoice not equal null");
-
+        if (hasChoice === "true") {
+            if (cookieForm) {
+                document.getElementById('cookies-analytics-yes').checked = true;
+            }
+            initializeClarity();
+        } else if (hasChoice === "false") {
+            if (cookieForm) {
+                document.getElementById('cookies-analytics-no').checked = true;
+            }
+        }
     } else {
         document.getElementById('cookie-banner').style.display = 'block';
-        console.log("in innitCookieConsent - hasChoice else");
     }
 }
 
@@ -43,31 +50,19 @@ document.getElementById('reject-cookies').onclick = function () {
     document.getElementById('cookie-banner').style.display = 'none';
 };
 
-document.addEventListener('DOMContentLoaded', function () {
-    const cookieForm = document.getElementById('cookie-form');
-    if (cookieForm) {
-
-        const hasChoice = cookie.read("cookie");
-        if (hasChoice === "true") {
-            document.getElementById('cookies-analytics-yes').checked = true;
-        } else if (hasChoice === "false") {
-            document.getElementById('cookies-analytics-no').checked = true;
+if (cookieForm) {
+    cookieForm.addEventListener('submit', function (event) {
+        event.preventDefault();
+        const analyticsCookies = document.querySelector('input[name="cookies[analytics]"]:checked').value;
+        if (analyticsCookies === "yes") {
+            cookie.create("cookie", "true", 365);
+            initializeClarity();
+        } else {
+            cookie.create("cookie", "false", 365);
         }
-
-        cookieForm.addEventListener('submit', function (event) {
-            event.preventDefault();
-            const analyticsCookies = document.querySelector('input[name="cookies[analytics]"]:checked').value;
-            if (analyticsCookies) {
-                cookie.create("cookie", "true", 365);
-                initializeClarity();
-
-            } else {
-                cookie.create("cookie", "false", 365);
-            }
-            document.getElementById('cookie-banner').style.display = 'none';
-        });
-    }
-});
+        document.getElementById('cookie-banner').style.display = 'none';
+    });
+}
 
 var cookie = {
     create: function (name, value, days) {

--- a/tests/cypress/e2e/EligibilityCheck/Cookie.spec.ts
+++ b/tests/cypress/e2e/EligibilityCheck/Cookie.spec.ts
@@ -40,11 +40,56 @@ describe('Cookie consent banner functionality', () => {
         cy.get('#cookie-banner').should('have.css', 'display', 'none');
     });
 
+    it('Should hide banner and set cookie when accepting analytics from the cookies page option', () => {
+        cy.visit('/');
+        cy.get('h1').should('include.text', 'Check if your children can get free school meals');
+        cy.contains('Start now').click()
+        cy.get('.govuk-footer__link[href="/Home/Cookies"]').click();
+        
+        // Select yes radio button and submit using Continue button then verify display state
+        cy.get('#cookies-analytics-yes').click();
+        cy.get('button.govuk-button').contains('Save cookie settings').click();
+
+        cy.get('#cookie-banner').should('have.css', 'display', 'none');
+        
+        // Verify banner stays hidden on next visit
+        cy.reload();
+        cy.get('#cookie-banner').should('have.css', 'display', 'none');
+    });
+
+    it('Should hide banner and set cookie when rejecting analytics from the cookies page option', () => {
+        cy.visit('/');
+        cy.get('h1').should('include.text', 'Check if your children can get free school meals');
+        cy.contains('Start now').click()
+        cy.get('.govuk-footer__link[href="/Home/Cookies"]').click();
+        
+        // Select no radio button and submit using Continue button then verify display state
+        cy.get('#cookies-analytics-no').click();
+        cy.get('button.govuk-button').contains('Save cookie settings').click();
+
+        cy.get('#cookie-banner').should('have.css', 'display', 'none');
+        
+        // Verify banner stays hidden on next visit
+        cy.reload();
+        cy.get('#cookie-banner').should('have.css', 'display', 'none');
+    });
+
     it('Should initialize Clarity when analytics are accepted', () => {
         cy.visit(Cypress.config().baseUrl ?? "");
     
         // Accept cookies
         cy.get('#accept-cookies').click();
+        cy.wait(1000);
+
+        // Verify Clarity script is added
+        cy.get('body')
+            .invoke('attr', 'data-clarity')
+            .then(($clarity) => {
+                    if($clarity) {
+                        cy.get('head script[src*="clarity"]');
+                    }
+                }
+            );
     });
 
     it('Should remove Clarity cookies when analytics are rejected', () => {


### PR DESCRIPTION
Removed redundant layout width code in layout which fixes various layout issues throughout the application. Added cookies accept/reject option to cookies page. Wired the cookies banner and cookies page selector to the back end javascript file functions. Updated tests.

https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_workitems/edit/185409