### PR TITLE
QA fix for 212109 - Parent Appeal - File type and file size requirements

### DIFF
--- a/CheckYourEligibility.FrontEnd/Controllers/CheckController.cs
+++ b/CheckYourEligibility.FrontEnd/Controllers/CheckController.cs
@@ -556,7 +556,7 @@ public class CheckController : Controller
             }
 
             //Handle no evidence files selected
-            if (request.EvidenceFiles == null || request.EvidenceFiles.Count == 0)
+            if (request.EvidenceFiles == null && updatedRequest.Evidence.EvidenceList.Count == 0)
             {
                 ModelState.AddModelError("EvidenceFiles", $"You have not selected a file");
                 TempData["ErrorMessage"] = "You have not selected a file";


### PR DESCRIPTION
Handle issue where a selected file that is both .exe and also over 10mb results in null reference exception unhandled by the system.

Also show error when no file selected.

[https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_boards/board/t/ECS/Stories?workitem=212109](https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_boards/board/t/ECS/Stories?workitem=212109)