### PR TITLE
238048-FSM-PARENT-HideCookiesSettingsWhenJavaScriptDisabled

### DIFF
--- a/CheckYourEligibility.FrontEnd/Views/Home/Cookies.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Home/Cookies.cshtml
@@ -107,37 +107,38 @@
         </tbody>
     </table>
 
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h2 class="govuk-heading-l">Change your cookie settings</h2>
-            <form id="cookie-form" action="/form-handler" method="post" novalidate>
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                            Do you want to accept analytics cookies?
-                        </legend>
-                        <div class="govuk-radios" data-module="govuk-radios">
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies[analytics]"
-                                       type="radio" value="yes">
-                                <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
-                                    Yes
-                                </label>
+    <div class="js-only">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h2 class="govuk-heading-l">Change your cookie settings</h2>
+                <form id="cookie-form" action="/form-handler" method="post" novalidate>
+                    <div class="govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                                Do you want to accept analytics cookies?
+                            </legend>
+                            <div class="govuk-radios" data-module="govuk-radios">
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies[analytics]"
+                                           type="radio" value="yes">
+                                    <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
+                                        Yes
+                                    </label>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies[analytics]"
+                                           type="radio" value="no" checked>
+                                    <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
+                                        No
+                                    </label>
+                                </div>
                             </div>
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies[analytics]"
-                                       type="radio" value="no" checked>
-                                <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
-                                    No
-                                </label>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-                <button type="submit" class="govuk-button" data-module="govuk-button">
-                    Save cookie settings
-                </button>
-            </form>
+                        </fieldset>
+                    </div>
+                    <button type="submit" class="govuk-button" data-module="govuk-button">
+                        Save cookie settings
+                    </button>
+                </form>
+            </div>
         </div>
-    </div>
-</div>
+    </div></div>

--- a/CheckYourEligibility.FrontEnd/wwwroot/css/site.css
+++ b/CheckYourEligibility.FrontEnd/wwwroot/css/site.css
@@ -237,3 +237,15 @@ hr:not([size]) {
 }
 
 /*END - HR style override as design use this as a spacer not a hr */
+
+/*BEGIN - Class with associated JS function in cookieFunctions.js to show content when JS is enabled */
+
+.js-only {
+    display: none;
+}
+
+.show {
+    display: block;
+}
+
+/*END - Class with associated JS function in cookieFunctions.js to show content when JS is enabled */

--- a/CheckYourEligibility.FrontEnd/wwwroot/js/cookieFunctions.js
+++ b/CheckYourEligibility.FrontEnd/wwwroot/js/cookieFunctions.js
@@ -4,6 +4,9 @@ import {initAll} from './govuk-frontend.min.js'
 
 initAll();
 
+// Can show elements only when JavaScript is enabled by using this class on the element
+document.querySelectorAll('.js-only').forEach(x => x.classList.add("show"))
+
 const cookieForm = document.getElementById('cookie-form');
 
 function initializeClarity() {


### PR DESCRIPTION
Hide the Cookie Consent form for non JS enabled users. Also re-useable JS and CSS for other elements requiring this ability.