### PR TITLE
Fix HTTP_PROXY command format in README

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -28,7 +28,7 @@ npm install cypress@13.8.1 --save-dev
 
 Certain machines may struggle to install Cypress and receive a certificate error. This can be overcome by getting the portal URL for your VPN and adding it to this command: 
 
-- HTTP_PROXY=https{url} npm i
+- HTTP_PROXY=https://your-proxy-url npm install
 
 3. Configuring Environment envariables
 


### PR DESCRIPTION
Updated HTTP_PROXY command in README for Cypress installation.