### PR TITLE
Elig 2778 fixqs s array limit bypass in its bracket notation allows do s via memory exhaustion

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -2313,9 +2313,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -2313,9 +2313,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "typescript": "^5.4.5"
   },
   "overrides": {
-  "qs": "6.14.1"
+  "qs": "6.15.0"
   },
   "scripts": {
     "parentE2e:electron": "cypress run --browser electron --spec 'cypress/e2e/EligibilityCheck'",

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,6 +14,9 @@
     "otplib": "^12.0.1",
     "typescript": "^5.4.5"
   },
+  "overrides": {
+  "qs": "6.14.1"
+  },
   "scripts": {
     "parentE2e:electron": "cypress run --browser electron --spec 'cypress/e2e/EligibilityCheck'",
     "adminE2e:electron": "cypress run --browser electron --spec 'cypress/e2e/Admin'",


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/ELIG-2778
Fixed ELIG-2778 by overriding the transitive `qs` dependency in `/tests` to a patched version.

Validation:
- `npm ls qs` confirms the overridden safe version is installed
- `npm audit` no longer reports `qs`

Notes:
- Remaining `jws` vulnerability is expected, as its fix is in a separate unmerged branch
- Remaining `js-yaml` and `lodash` findings are unrelated to this ticket