### PR TITLE
Elig 2777 fixminimatch has re do s match one combinatorial backtracking via multiple non adjacent globstar segments

### DIFF
--- a/CheckYourEligibility.FrontEnd/package-lock.json
+++ b/CheckYourEligibility.FrontEnd/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "checkYourEligibility-parent",
+  "name": "checkyoureligibility-parent",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "checkYourEligibility-parent",
+      "name": "checkyoureligibility-parent",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -800,10 +800,11 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },

--- a/CheckYourEligibility.FrontEnd/package.json
+++ b/CheckYourEligibility.FrontEnd/package.json
@@ -11,6 +11,9 @@
   "dependencies": {
     "govuk-frontend": "^5.9.0"
   },
+  "overrides": {
+  "minimatch": "3.1.4"
+  },
   "devDependencies": {
     "eslint": "^8.57.0"
   }


### PR DESCRIPTION
Confirmed this ticket applies to `CheckYourEligibility.FrontEnd/package-lock.json`.

The vulnerable transitive dependency was introduced via:
- `eslint 8.57.0` → `minimatch 3.1.2`

Applied npm override:
- `minimatch` → `3.1.4`

Validation:
- Ran `npm install`
- Verified via `npm ls minimatch` that all instances now resolve to `3.1.4`
- Re-ran `npm audit` and confirmed the minimatch vulnerability is cleared

Remaining audit findings are unrelated to minimatch and are out of scope for this ticket.

https://dfedigital.atlassian.net/browse/ELIG-2777