### PR TITLE
  ELIG-2797   FixMissing X-Frame-Options HTTP header

### DIFF
--- a/CheckYourEligibility.FrontEnd/Web.config
+++ b/CheckYourEligibility.FrontEnd/Web.config
@@ -1,12 +1,13 @@
 <configuration>
-    <system.webServer>
-        <security>
-            <requestFiltering removeServerHeader="true"/>
-        </security>
-        <httpProtocol>
-            <customHeaders>
-                <remove name="X-Powered-By"/>
-            </customHeaders>
-        </httpProtocol>
-    </system.webServer>
+	<system.webServer>
+		<security>
+			<requestFiltering removeServerHeader="true"/>
+		</security>
+		<httpProtocol>
+			<customHeaders>
+				<remove name="X-Powered-By"/>
+				<add name="X-Frame-Options" value="DENY" />
+			</customHeaders>
+		</httpProtocol>
+	</system.webServer>
 </configuration>


### PR DESCRIPTION
## Investigation

CodeQL flagged a high severity vulnerability (`cs/web/missing-x-frame-options`) in `CheckYourEligibility.FrontEnd/Web.config`.

The application configuration did not include the `X-Frame-Options` HTTP header, which could allow the site to be embedded within an iframe and expose it to clickjacking attacks.

## Fix

- Updated `CheckYourEligibility.FrontEnd/Web.config`
- Added the `X-Frame-Options` header under `system.webServer > httpProtocol > customHeaders`
- Set the value to `DENY`

## Outcome

The application now includes the `X-Frame-Options: DENY` header in responses, mitigating clickjacking risks and resolving the CodeQL alert.

https://dfedigital.atlassian.net/browse/ELIG-2797