### PR TITLE
ELIG-2879-ParentPortal-Ensure-screen-reader-users-can-distinguish-between-page-sections-by-giving-each-landmark-a-unique-name

### DIFF
--- a/CheckYourEligibility.FrontEnd/Views/Home/Index.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Home/Index.cshtml
@@ -6,8 +6,8 @@
     // url = url.Replace("as", "as-admin");
 }
 
-<div class="govuk-width-container ">
-    <main class="govuk-main-wrapper " id="main-content" role="main">
+<div class="govuk-width-container">
+    <div class="govuk-main-wrapper">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <h1 class="govuk-heading-xl">@ViewData["Title"]</h1>
@@ -48,5 +48,5 @@
                 </a>
             </div>
         </div>
-    </main>
+    </div>
 </div>

--- a/CheckYourEligibility.FrontEnd/Views/Shared/_Layout.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Shared/_Layout.cshtml
@@ -57,7 +57,7 @@
                     </span>
             </a>
         </div>
-        <nav id="header-navigation" class="dfe-header__navigation" aria-label="Primary navigation"
+        <div id="header-navigation" class="dfe-header__navigation"
              aria-labelledby="label-navigation">
             <div id="spacerForNoLinkContentRemoveWhenAddingLinksBelow">
                 &nbsp;
@@ -72,11 +72,11 @@
                 </li>
                 </ul>*@
 
-        </nav>
+        </div>
     </div>
 </header>
 
-<div class="app-phase-banner__wrapper">
+    <div class="app-phase-banner__wrapper" role="complementary">
     <div class="govuk-phase-banner app-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
             <strong class="govuk-tag govuk-phase-banner__content__tag">

--- a/CheckYourEligibility.FrontEnd/Views/Shared/_Layout_StartNow.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Shared/_Layout_StartNow.cshtml
@@ -64,7 +64,7 @@
     </div>
 </header>
 
-<div class="app-phase-banner__wrapper">
+    <div class="app-phase-banner__wrapper" role="complementary">
 
     <div class="govuk-phase-banner app-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">


### PR DESCRIPTION
- Add complimentary landmark to beta banner. 
- Ensure only one 'main' landmark exists per page.
- Remove navigation landmark from landing page as no navigation exists.

[https://dfedigital.atlassian.net/browse/ELIG-2879](https://dfedigital.atlassian.net/browse/ELIG-2879)