### PR TITLE
ELIG-2869-PARENT-Ensure-error-messages-are-clear-and-accurate-for-screen-reader-users

### DIFF
--- a/CheckYourEligibility.FrontEnd.Tests/Attributes/NassAttributeTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Attributes/NassAttributeTests.cs
@@ -7,8 +7,8 @@ namespace CheckYourEligibility.FrontEnd.Tests.Attributes;
 
 public class NassAttributeTests
 {
-    private const string NASSMissingErrorMessage = "Nass is required";
-    private const string NASSFormatErrorMessage = "Nass field contains an invalid character";
+    private const string NASSMissingErrorMessage = "Asylum support reference number is required";
+    private const string NASSFormatErrorMessage = "Asylum support reference number must only include numbers";
 
     private TestableNassAttribute _nassAttribute { get; set; }
     private ValidationContext _validationContext { get; set; }

--- a/CheckYourEligibility.FrontEnd.Tests/Attributes/NinoAttributeTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Attributes/NinoAttributeTests.cs
@@ -8,7 +8,7 @@ namespace CheckYourEligibility.FrontEnd.Tests.Attributes;
 public class NinoAttributeTests
 {
     private const string NINOMissingErrorMessage = "National Insurance number is required";
-    private const string NINOFormatErrorMessage = "Invalid National Insurance number format";
+    private const string NINOFormatErrorMessage = "Enter a National Insurance number in the correct format";
 
     private TestableNinoAttribute _ninoAttribute { get; set; }
     private ValidationContext _validationContext { get; set; }

--- a/CheckYourEligibility.FrontEnd/Attributes/IsNinoSelectedAttribute.cs
+++ b/CheckYourEligibility.FrontEnd/Attributes/IsNinoSelectedAttribute.cs
@@ -14,7 +14,7 @@ internal class IsNinoSelectedAttribute : ValidationAttribute
         if (model.IsNassSelected == null && model.IsNinoSelected == false) return ValidationResult.Success;
 
         if (model.IsNassSelected == null && model.NASSRedirect)
-            return new ValidationResult("Select yes if you have an Asylum support reference number");
+            return new ValidationResult("Select yes if you have an asylum support reference number");
         return ValidationResult.Success;
     }
 }

--- a/CheckYourEligibility.FrontEnd/Attributes/IsNinoSelectedAttribute.cs
+++ b/CheckYourEligibility.FrontEnd/Attributes/IsNinoSelectedAttribute.cs
@@ -14,7 +14,7 @@ internal class IsNinoSelectedAttribute : ValidationAttribute
         if (model.IsNassSelected == null && model.IsNinoSelected == false) return ValidationResult.Success;
 
         if (model.IsNassSelected == null && model.NASSRedirect)
-            return new ValidationResult("Select yes if you have a National Asylum Seeker Service number");
+            return new ValidationResult("Select yes if you have an Asylum support reference number");
         return ValidationResult.Success;
     }
 }

--- a/CheckYourEligibility.FrontEnd/Attributes/NassAttribute.cs
+++ b/CheckYourEligibility.FrontEnd/Attributes/NassAttribute.cs
@@ -16,10 +16,10 @@ public class NassAttribute : ValidationAttribute
 
         if (model.IsNassSelected == true)
         {
-            if (value == null || value == "") return new ValidationResult("Nass is required");
+            if (value == null || value == "") return new ValidationResult("Asylum support reference number is required");
 
             if (!regex.IsMatch(value.ToString()))
-                return new ValidationResult("Nass field contains an invalid character");
+                return new ValidationResult("Asylum support reference number must only include numbers");
         }
 
         return ValidationResult.Success;

--- a/CheckYourEligibility.FrontEnd/Attributes/NinoAttribute.cs
+++ b/CheckYourEligibility.FrontEnd/Attributes/NinoAttribute.cs
@@ -36,7 +36,7 @@ public class NinoAttribute : ValidationAttribute
             return new ValidationResult(
                 "National Insurance number should contain no more than 9 alphanumeric characters");
 
-        if (!regex.IsMatch(nino)) return new ValidationResult("Invalid National Insurance number format");
+        if (!regex.IsMatch(nino)) return new ValidationResult("Enter a National Insurance number in the correct format");
 
         model.NationalInsuranceNumber = nino;
 

--- a/CheckYourEligibility.FrontEnd/Domain/Constants/ErrorMessages/ApplicationValidationMessages.cs
+++ b/CheckYourEligibility.FrontEnd/Domain/Constants/ErrorMessages/ApplicationValidationMessages.cs
@@ -5,7 +5,7 @@ namespace CheckYourEligibility.FrontEnd.Domain.Constants.ErrorMessages;
 public static class ValidationMessages
 {
     public const string NI_and_NASS =
-        "National Insurance number or Asylum support reference number is required is required, not both";
+        "National Insurance number or asylum support reference number is required, not both";
 
     public const string DOB = "Date of birth is required:- (yyyy-mm-dd)";
     public const string ChildDOB = "Child Date of birth is required:- (yyyy-mm-dd)";
@@ -14,5 +14,5 @@ public static class ValidationMessages
     public const string ChildLastName = "Child LastName is required";
     public const string ChildFirstName = "Child FirstName is required";
     public const string NI = "Invalid National Insurance number";
-    public const string NI_or_NASS = "National Insurance number or Asylum support reference number is required";
+    public const string NI_or_NASS = "National Insurance number or asylum support reference number is required";
 }

--- a/CheckYourEligibility.FrontEnd/Domain/Constants/ErrorMessages/ApplicationValidationMessages.cs
+++ b/CheckYourEligibility.FrontEnd/Domain/Constants/ErrorMessages/ApplicationValidationMessages.cs
@@ -5,7 +5,7 @@ namespace CheckYourEligibility.FrontEnd.Domain.Constants.ErrorMessages;
 public static class ValidationMessages
 {
     public const string NI_and_NASS =
-        "National Insurance Number or National Asylum Seeker Service Number is required is required, not both";
+        "National Insurance number or Asylum support reference number is required is required, not both";
 
     public const string DOB = "Date of birth is required:- (yyyy-mm-dd)";
     public const string ChildDOB = "Child Date of birth is required:- (yyyy-mm-dd)";
@@ -13,6 +13,6 @@ public static class ValidationMessages
     public const string FirstName = "FirstName is required";
     public const string ChildLastName = "Child LastName is required";
     public const string ChildFirstName = "Child FirstName is required";
-    public const string NI = "Invalid National Insurance Number";
-    public const string NI_or_NASS = "National Insurance Number or National Asylum Seeker Service Number is required";
+    public const string NI = "Invalid National Insurance number";
+    public const string NI_or_NASS = "National Insurance number or Asylum support reference number is required";
 }

--- a/CheckYourEligibility.FrontEnd/Views/Check/Nass.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Check/Nass.cshtml
@@ -13,78 +13,73 @@
     @if (!ViewData.ModelState.IsValid)
     {
         ViewData["Title"] = "Error: Do you have an asylum support reference number?";
-        <partial name="_ValidationSummaryParent" model="ViewData.ModelState"/>
+        <partial name="_ValidationSummaryParent" model="ViewData.ModelState" />
     }
 
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <form asp-controller="Check" asp-action="Enter_Details" method="post" novalidate>
-                <input type="hidden" asp-for="FirstName" value="@parent.FirstName"/>
-                <input type="hidden" asp-for="LastName" value="@parent.LastName"/>
-                <input type="hidden" asp-for="Day" value="@parent.Day"/>
-                <input type="hidden" asp-for="Month" value="@parent.Month"/>
-                <input type="hidden" asp-for="Year" value="@parent.Year"/>
-                <input type="hidden" asp-for="NASSRedirect" value="@parent.NASSRedirect"/>
+    <form asp-controller="Check" asp-action="Enter_Details" method="post" novalidate>
+        <input type="hidden" asp-for="FirstName" value="@parent.FirstName" />
+        <input type="hidden" asp-for="LastName" value="@parent.LastName" />
+        <input type="hidden" asp-for="Day" value="@parent.Day" />
+        <input type="hidden" asp-for="Month" value="@parent.Month" />
+        <input type="hidden" asp-for="Year" value="@parent.Year" />
+        <input type="hidden" asp-for="NASSRedirect" value="@parent.NASSRedirect" />
 
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset" aria-describedby="nass-number-hint">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                            <h1 class="govuk-fieldset__heading">@ViewData["Title"]</h1>
-                        </legend>
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" aria-describedby="nass-number-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                    <h1 class="govuk-fieldset__heading">@ViewData["Title"]</h1>
+                </legend>
 
-                        <div id="nass-number-hint" class="govuk-hint">
-                            This can be found on letters from the Home Office. It was previously known as a NASS number.
-                        </div>
-                        <p class="govuk-error-message">
-                            <span asp-validation-for="IsNinoSelected"></span>
-                        </p>
-                        <div class="govuk-radios" data-module="govuk-radios">
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="IsNinoSelected" asp-for="IsNassSelected"
-                                       type="radio" value="true" aria-controls="conditional-nass-number"
-                                       aria-expanded="false" aria-label="Yes">
-                                <label class="govuk-label govuk-radios__label" for="NationalAsylumSeekerServiceNumber">
-                                    Yes
-                                </label>
-                            </div>
-
-                            <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-                                 id="conditional-nass-number">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label" for="nass-number-entered">
-                                        Asylum support reference number
-                                    </label>
-                                    <div id="nass-number-entered-hint" class="govuk-hint">
-                                        Enter the first 9 numbers
-                                    </div>
-                                    <p class="govuk-error-message">
-                                        <span asp-validation-for="NationalAsylumSeekerServiceNumber"></span>
-                                    </p>
-                                    <input
-                                        class="govuk-input govuk-!-width-one-third @(ViewData.ModelState["NationalAsylumSeekerServiceNumber"]?.Errors.Count > 0 ? "govuk-input--error" : "")"
-                                        asp-for="NationalAsylumSeekerServiceNumber" type="text" inputmode="numeric"
-                                        maxlength="10" spellcheck="false" aria-describedby="nass-number-entered-hint"
-                                        autocomplete="text">
-                                </div>
-                            </div>
-
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="IsNinoSelected" asp-for="IsNassSelected"
-                                       type="radio" value="false">
-                                <label class="govuk-label govuk-radios__label" for="nass-number-2">
-                                    No, I do not have one
-                                </label>
-                            </div>
-                        </div>
-                    </fieldset>
+                <div id="nass-number-hint" class="govuk-hint">
+                    This can be found on letters from the Home Office. It was previously known as a NASS number.
                 </div>
+                <p class="govuk-error-message">
+                    <span asp-validation-for="IsNinoSelected"></span>
+                </p>
+                <div class="govuk-radios" data-module="govuk-radios">
+                    <div class="govuk-radios__item">
+                        <input class="govuk-radios__input" id="IsNinoSelected" asp-for="IsNassSelected"
+                               type="radio" value="true" aria-controls="conditional-nass-number"
+                               aria-expanded="false" aria-label="Yes">
+                        <label class="govuk-label govuk-radios__label" for="NationalAsylumSeekerServiceNumber">
+                            Yes
+                        </label>
+                    </div>
 
-                <button type="submit" class="govuk-button" data-module="govuk-button">
-                    Save and continue
-                </button>
-            </form>
+                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+                         id="conditional-nass-number">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label" for="nass-number-entered">
+                                Asylum support reference number
+                            </label>
+                            <div id="nass-number-entered-hint" class="govuk-hint">
+                                Enter the first 9 numbers
+                            </div>
+                            <p class="govuk-error-message">
+                                <span asp-validation-for="NationalAsylumSeekerServiceNumber"></span>
+                            </p>
+                            <input class="govuk-input govuk-!-width-one-third @(ViewData.ModelState["NationalAsylumSeekerServiceNumber"]?.Errors.Count > 0 ? "govuk-input--error" : "")"
+                                   asp-for="NationalAsylumSeekerServiceNumber" type="text" inputmode="numeric"
+                                   maxlength="10" spellcheck="false" aria-describedby="nass-number-entered-hint"
+                                   autocomplete="text">
+                        </div>
+                    </div>
+
+                    <div class="govuk-radios__item">
+                        <input class="govuk-radios__input" id="IsNinoSelected" asp-for="IsNassSelected"
+                               type="radio" value="false">
+                        <label class="govuk-label govuk-radios__label" for="nass-number-2">
+                            No, I do not have one
+                        </label>
+                    </div>
+                </div>
+            </fieldset>
         </div>
-    </div>
+
+        <button type="submit" class="govuk-button" data-module="govuk-button">
+            Save and continue
+        </button>
+    </form>
 </div>
 
 <script src="/js/validationSummary.js"></script>

--- a/tests/cypress/e2e/EligibilityCheck/ErrorsMessagesFullParentE2E.spec.ts
+++ b/tests/cypress/e2e/EligibilityCheck/ErrorsMessagesFullParentE2E.spec.ts
@@ -152,7 +152,7 @@ describe('Parent with valid details can complete full Eligibility check and appl
         cy.get('#NationalAsylumSeekerServiceNumber').should('be.visible').type('999999999');
         cy.contains('Save and continue').click();
 
-        cy.get('.govuk-error-message').should('contain', 'Nass field contains an invalid character');
+        cy.get('.govuk-error-message').should('contain', 'Asylum support reference number must only include numbers');
         cy.get('#NationalAsylumSeekerServiceNumber').should('be.visible').clear().type('110111111');
         cy.contains('Save and continue').click();
         

--- a/tests/cypress/e2e/EligibilityCheck/ParentNotEligible.spec.ts
+++ b/tests/cypress/e2e/EligibilityCheck/ParentNotEligible.spec.ts
@@ -95,7 +95,7 @@ describe('Parents journey when not eligible', () => {
         cy.contains('Save and continue').click();
 
         cy.get('h2').should('include.text', 'There is a problem');
-        cy.get('a').should('include.text', 'Invalid National Insurance number format');
+        cy.get('a').should('include.text', 'Enter a National Insurance number in the correct format');
     });
 
     it('Will return the correct error response if the user inputs a NI number is too long', () => {


### PR DESCRIPTION
- Update NI and Asylum support reference number validation messages. 
- Updated texts displaying Nass or National Asylum Seeker Service number.
- Fix some incorrect casing on National Insurance number texts (decapitalise 'n' in number).

https://dfedigital.atlassian.net/browse/ELIG-2869
