### PR TITLE
ELIG-3050 PARENT Accessibility fixed missed in second round

### DIFF
--- a/CheckYourEligibility.FrontEnd/Views/Check/Check_Answers.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Check/Check_Answers.cshtml
@@ -109,7 +109,7 @@
                 </h2>
                 <ul class="govuk-summary-card__actions">
                     <li class="govuk-summary-card__action">
-                        @Html.ActionLink("Change", "ChangeChildDetails", new { child = i })
+                        @Html.ActionLink("Change", "ChangeChildDetails", new { child = i }, new { aria_label = "Change Child" + (i + 1) + "details" })
                     </li>
 
                 </ul>

--- a/CheckYourEligibility.FrontEnd/Views/Check/Enter_Child_Details.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Check/Enter_Child_Details.cshtml
@@ -92,7 +92,7 @@
                     </div>
 
                     <div class="govuk-form-group">
-                        <fieldset class="govuk-fieldset" role="group" aria-describedby="school-picker-hint">
+                        <fieldset class="govuk-fieldset" role="group" aria-describedby="school-picker-hint-@i">
                             <label class="govuk-label govuk-!-font-weight-bold noJsRemove" for="ChildList[@i].School">
                                 School
                             </label>

--- a/CheckYourEligibility.FrontEnd/Views/Check/Enter_Child_Details.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Check/Enter_Child_Details.cshtml
@@ -39,8 +39,6 @@
     <p>Include all children who are in compulsory education.</p>
 
     <form asp-controller="Check" asp-action="Enter_Child_Details" method="post" novalidate>
-
-
         @for (var i = 0; i < Model.ChildList.Count; i++)
         {
             <input type="hidden" asp-for="ChildList[i].ChildIndex" value="@(i + 1)" id="ChildIndex" />
@@ -99,19 +97,26 @@
                                 School
                             </label>
 
-                            <div id="school-picker-hint" class="govuk-hint noJsRemove" aria-label="Type to search">
+                            <div id="school-picker-hint-@i"
+                                 class="govuk-hint noJsRemove">
                                 Type to search
                             </div>
 
                             <p class="govuk-error-message">
                                 <span asp-validation-for="ChildList[i].School.URN"></span>
                             </p>
+
                             <input id="ChildList[@i].School"
                                    class="noJsRemove govuk-search school-search govuk-input @(ViewData.ModelState[$"ChildList[{i}].School.URN"]?.Errors.Count > 0 ? "govuk-input--error" : "")"
-                                   value="@(Model.ChildList[i].School != null && !string.IsNullOrEmpty(Model.ChildList[i].School.URN) ? string.Join(", ", Model.ChildList[i].School.Name, Model.ChildList[i].School.URN, Model.ChildList[i].School.Postcode, Model.ChildList[i].School.LA) : "")"
                                    type="text"
                                    autocomplete="off"
-                                   aria-describedby="school-picker-hint" />
+                                   aria-describedby="school-picker-hint-@i"
+                                   role="combobox"
+                                   aria-autocomplete="list"
+                                   aria-expanded="false"
+                                   aria-controls="schoolList@(i)"
+                                   aria-activedescendant=""
+                                   value="@(Model.ChildList[i].School != null && !string.IsNullOrEmpty(Model.ChildList[i].School.URN) ? string.Join(", ", Model.ChildList[i].School.Name, Model.ChildList[i].School.URN, Model.ChildList[i].School.Postcode, Model.ChildList[i].School.LA) : "")" />
 
                             <input hidden asp-for="ChildList[i].School.ChildIndex" id="ChildList[@i].School.ChildIndex"
                                    value="@(i + 1)" />
@@ -124,7 +129,10 @@
                                    class="noJsShow govuk-search govuk-input" aria-label="School" />
                             <input hidden asp-for="ChildList[i].School.Postcode" id="ChildList[@i].School.Postcode" />
                             <input hidden asp-for="ChildList[i].School.LA" id="ChildList[@i].School.LA" />
-                            <ul id="schoolList@(i)" class="govuk-!-width-two-thirds"></ul>
+                            <ul id="schoolList@(i)"
+                                class="govuk-!-width-two-thirds"
+                                role="listbox"
+                                hidden></ul>
                         </fieldset>
                         <noscript>
                             <details class="govuk-details" open="">

--- a/CheckYourEligibility.FrontEnd/Views/Home/SchoolList.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Home/SchoolList.cshtml
@@ -34,7 +34,7 @@
 
     <form asp-controller="Home" asp-action="SchoolList" method="post" novalidate>
         <div class="govuk-form-group">
-            <label class="govuk-label govuk-!-font-weight-bold" for="school-list-search">
+            <label class="govuk-label govuk-!-font-weight-bold" for="SelectedSchoolURN">
                 Search schools
             </label>
 
@@ -43,8 +43,14 @@
             </p>
 
             <input id="SelectedSchoolURN"
-                class="govuk-input school-list-search @(ViewData.ModelState["SelectedSchoolURN"]?.Errors.Count > 0 ? "govuk-input--error" : "")"
-                type="text" autocomplete="off" aria-label="School Search" />
+                   class="govuk-input school-list-search @(ViewData.ModelState["SelectedSchoolURN"]?.Errors.Count > 0 ? "govuk-input--error" : "")"
+                   type="text"
+                   autocomplete="off"
+                   role="combobox"
+                   aria-autocomplete="list"
+                   aria-expanded="false"
+                   aria-controls="schoolListResults"
+                   aria-activedescendant="" />
 
             <input type="hidden" asp-for="SelectedSchoolURN" id="SelectedSchoolURNHidden" />
             <input type="hidden" asp-for="SelectedSchoolName" id="SelectedSchoolName" />
@@ -52,7 +58,10 @@
             <input type="hidden" asp-for="SelectedSchoolPostcode" id="SelectedSchoolPostcode" />
             <input type="hidden" asp-for="SelectedSchoolInPrivateBeta" id="SelectedSchoolInPrivateBeta" />
 
-            <ul id="schoolListResults" class="govuk-!-width-two-thirds"></ul>
+            <ul id="schoolListResults"
+                class="govuk-!-width-two-thirds"
+                role="listbox"
+                hidden></ul>
         </div>
 
 

--- a/CheckYourEligibility.FrontEnd/Views/Shared/_Layout.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Shared/_Layout.cshtml
@@ -34,12 +34,10 @@
             </div>
 
             <div class="govuk-button-group">
-                <button type="button" class="govuk-button" id="accept-cookies" data-module="govuk-button"
-                        data-govuk-button-init="">
+                <button type="button" class="govuk-button" id="accept-cookies" data-module="govuk-button">
                     Accept analytics cookies
                 </button>
-                <button type="button" class="govuk-button" id="reject-cookies" data-module="govuk-button"
-                        data-govuk-button-init="">
+                <button type="button" class="govuk-button" id="reject-cookies" data-module="govuk-button">
                     Reject analytics cookies
                 </button>
                 <a class="govuk-link" href="/Home/Cookies">View cookies</a>

--- a/CheckYourEligibility.FrontEnd/Views/Shared/_Layout_StartNow.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Shared/_Layout_StartNow.cshtml
@@ -27,12 +27,10 @@
         </div>
 
         <div class="govuk-button-group">
-            <button type="button" class="govuk-button" id="accept-cookies" data-module="govuk-button"
-                    data-govuk-button-init="">
+            <button type="button" class="govuk-button" id="accept-cookies" data-module="govuk-button">
                 Accept analytics cookies
             </button>
-            <button type="button" class="govuk-button" id="reject-cookies" data-module="govuk-button"
-                    data-govuk-button-init="">
+            <button type="button" class="govuk-button" id="reject-cookies" data-module="govuk-button">
                 Reject analytics cookies
             </button>
             <a class="govuk-link" href="/Home/Cookies">View cookies</a>

--- a/CheckYourEligibility.FrontEnd/wwwroot/css/site.css
+++ b/CheckYourEligibility.FrontEnd/wwwroot/css/site.css
@@ -73,9 +73,9 @@ table {
     text-decoration: none;
 }
 
-#content-header .dfe-header__action-links a:hover {
-    text-decoration: underline;
-}
+    #content-header .dfe-header__action-links a:hover {
+        text-decoration: underline;
+    }
 
 .govuk-pagination {
     justify-content: center;
@@ -108,9 +108,9 @@ table {
     width: auto;
 }
 
-.moj-button-menu__item:last-child {
-    margin-right: 0;
-}
+    .moj-button-menu__item:last-child {
+        margin-right: 0;
+    }
 
 /* END MENU ITEM */
 
@@ -255,3 +255,10 @@ hr:not([size]) {
     height: 137px;
 }
 /*END - Make blue header larger after removing nav. Remove this if adding a nav element later */
+
+/*BEGIN - SchoolListSearch in SchoolList should be accessible using only the keyboard*/
+[role="option"][aria-selected="true"] {
+    background-color: #ffdd00; /* GOV.UK focus yellow */
+    outline: 2px solid #0b0c0c;
+}
+/*END - SchoolListSearch in SchoolList should be accessible using only the keyboard*/

--- a/CheckYourEligibility.FrontEnd/wwwroot/js/schoolListSearch.js
+++ b/CheckYourEligibility.FrontEnd/wwwroot/js/schoolListSearch.js
@@ -1,5 +1,11 @@
+let activeIndex = -1;
+let currentResults = [];
+
 function searchSchoolList(query) {
-    if (query.length >= 3 && query !== null) {
+    const list = document.getElementById('schoolListResults');
+    const input = document.getElementById('SelectedSchoolURN');
+
+    if (query && query.length >= 3) {
         fetch('/Check/SearchSchools?query=' + encodeURIComponent(query))
             .then(response => {
                 if (!response.ok) {
@@ -8,44 +14,150 @@ function searchSchoolList(query) {
                 return response.json();
             })
             .then(data => {
-                document.getElementById('schoolListResults').innerHTML = '';
-                let counter = 0;
-                data.forEach(function (value) {
-                    var li = document.createElement('li');
-                    li.setAttribute('id', value.id);
-                    li.setAttribute('value', value.name);
-                    li.setAttribute('class', counter % 2 === 0 ? 'autocomplete__option' : 'autocomplete__option autocomplete__option--odd');
-                    li.innerHTML = `${value.name}, ${value.id}, ${value.postcode}, ${value.la}`;
-                    li.addEventListener('click', function () {
-                        selectSchoolFromList(value.name, value.id, value.la, value.postcode, value.inPrivateBeta);
+                list.innerHTML = '';
+                currentResults = data;
+                activeIndex = -1;
+
+                if (data.length === 0) {
+                    closeList();
+                    return;
+                }
+
+                data.forEach((value, index) => {
+                    const li = document.createElement('li');
+
+                    li.id = `school-option-${index}`;
+                    li.setAttribute('role', 'option');
+                    li.setAttribute('aria-selected', 'false');
+                    li.className =
+                        index % 2 === 0
+                            ? 'autocomplete__option'
+                            : 'autocomplete__option autocomplete__option--odd';
+
+                    li.textContent = `${value.name}, ${value.id}, ${value.postcode}, ${value.la}`;
+
+                    li.addEventListener('click', () => {
+                        selectSchoolFromList(
+                            value.name,
+                            value.id,
+                            value.la,
+                            value.postcode,
+                            value.inPrivateBeta
+                        );
                     });
-                    document.getElementById('schoolListResults').appendChild(li);
-                    counter++;
+
+                    list.appendChild(li);
                 });
+
+                openList();
             })
-            .catch(error => {
-                console.error('Error searching schools:', error);
-                document.getElementById('schoolListResults').innerHTML = '<li class="autocomplete__option">Error searching schools</li>';
+            .catch(() => {
+                list.innerHTML = '<li role="option">Error searching schools</li>';
+                openList();
             });
     } else {
-        document.getElementById('schoolListResults').innerHTML = '';
+        closeList();
+    }
+}
+
+function openList() {
+    const list = document.getElementById('schoolListResults');
+    const input = document.getElementById('SelectedSchoolURN');
+
+    list.hidden = false;
+    input.setAttribute('aria-expanded', 'true');
+}
+
+function closeList() {
+    const list = document.getElementById('schoolListResults');
+    const input = document.getElementById('SelectedSchoolURN');
+
+    list.hidden = true;
+    input.setAttribute('aria-expanded', 'false');
+    input.removeAttribute('aria-activedescendant');
+    activeIndex = -1;
+}
+
+function setActiveOption(index) {
+    const list = document.getElementById('schoolListResults');
+    const input = document.getElementById('SelectedSchoolURN');
+    const options = list.querySelectorAll('[role="option"]');
+
+    options.forEach(option => option.setAttribute('aria-selected', 'false'));
+
+    const activeOption = options[index];
+    if (activeOption) {
+        activeOption.setAttribute('aria-selected', 'true');
+        input.setAttribute('aria-activedescendant', activeOption.id);
+        activeIndex = index;
+    }
+}
+
+function handleKeyDown(event) {
+    const list = document.getElementById('schoolListResults');
+    const options = list.querySelectorAll('[role="option"]');
+
+    if (list.hidden || options.length === 0) {
+        return;
+    }
+
+    switch (event.key) {
+        case 'ArrowDown':
+            event.preventDefault();
+            setActiveOption(
+                activeIndex < options.length - 1 ? activeIndex + 1 : 0
+            );
+            break;
+
+        case 'ArrowUp':
+            event.preventDefault();
+            setActiveOption(
+                activeIndex > 0 ? activeIndex - 1 : options.length - 1
+            );
+            break;
+
+        case 'Enter':
+            event.preventDefault();
+            if (activeIndex >= 0) {
+                const value = currentResults[activeIndex];
+                selectSchoolFromList(
+                    value.name,
+                    value.id,
+                    value.la,
+                    value.postcode,
+                    value.inPrivateBeta
+                );
+            }
+            break;
+
+        case 'Escape':
+            closeList();
+            break;
     }
 }
 
 function selectSchoolFromList(school, urn, la, postcode, inPrivateBeta) {
-    document.getElementById('SelectedSchoolURN').value = `${school}, ${urn}, ${postcode}, ${la}`;
+    document.getElementById('SelectedSchoolURN').value =
+        `${school}, ${urn}, ${postcode}, ${la}`;
+
     document.getElementById('SelectedSchoolURNHidden').value = urn;
     document.getElementById('SelectedSchoolName').value = school;
     document.getElementById('SelectedSchoolLA').value = la;
     document.getElementById('SelectedSchoolPostcode').value = postcode;
-    document.getElementById('SelectedSchoolInPrivateBeta').value = inPrivateBeta === true ? 'true' : 'false';
-    document.getElementById('schoolListResults').innerHTML = '';
+    document.getElementById('SelectedSchoolInPrivateBeta').value =
+        inPrivateBeta === true ? 'true' : 'false';
+
+    closeList();
 }
 
-// Set up event listener for the school list search input
-var schoolListSearchInput = document.querySelector('.school-list-search');
+/* Event listeners */
+const schoolListSearchInput =
+    document.querySelector('.school-list-search');
+
 if (schoolListSearchInput) {
-    schoolListSearchInput.oninput = function () {
+    schoolListSearchInput.addEventListener('input', function () {
         searchSchoolList(this.value);
-    }
+    });
+
+    schoolListSearchInput.addEventListener('keydown', handleKeyDown);
 }

--- a/CheckYourEligibility.FrontEnd/wwwroot/js/schoolSearch.js
+++ b/CheckYourEligibility.FrontEnd/wwwroot/js/schoolSearch.js
@@ -1,67 +1,124 @@
-function searchSchool(query, index) {
-    var id = `ChildList[${index}].school.Name`
-    if (query.length >= 3 && query !== null) {
-        // Updated to use new SearchSchools endpoint
+document.addEventListener('DOMContentLoaded', () => {
+
+    const activeIndex = {};
+    const resultCache = {};
+
+    function openList(index) {
+        const input = document.getElementById(`ChildList[${index}].School`);
+        const list = document.getElementById(`schoolList${index}`);
+        list.hidden = false;
+        input.setAttribute('aria-expanded', 'true');
+    }
+
+    function closeList(index) {
+        const input = document.getElementById(`ChildList[${index}].School`);
+        const list = document.getElementById(`schoolList${index}`);
+        list.hidden = true;
+        list.innerHTML = '';
+        input.setAttribute('aria-expanded', 'false');
+        input.removeAttribute('aria-activedescendant');
+        activeIndex[index] = -1;
+    }
+
+    function setActive(index, optionIndex) {
+        const list = document.getElementById(`schoolList${index}`);
+        const options = list.querySelectorAll('[role="option"]');
+
+        options.forEach(o => o.setAttribute('aria-selected', 'false'));
+
+        const option = options[optionIndex];
+        if (!option) return;
+
+        option.setAttribute('aria-selected', 'true');
+        document
+            .getElementById(`ChildList[${index}].School`)
+            .setAttribute('aria-activedescendant', option.id);
+
+        activeIndex[index] = optionIndex;
+    }
+
+    function searchSchool(query, index) {
+        if (!query || query.length < 3) {
+            closeList(index);
+            return;
+        }
+
         fetch('/Check/SearchSchools?query=' + encodeURIComponent(query))
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error('Search failed');
-                }
-                return response.json();
-            })
+            .then(r => r.json())
             .then(data => {
-                document.getElementById(`schoolList${index}`).innerHTML = '';
-                let counter = 0;
-                // loop response and add li elements with an onclick event listener to select the school
-                data.forEach(function (value) {
-                    var li = document.createElement('li');
-                    li.setAttribute('id', value.id);
-                    li.setAttribute('value', `${value.name}`);
-                    // Check if the counter is even, if not add the 'autocomplete__option--odd' class
-                    li.setAttribute('class', counter % 2 === 0 ? 'autocomplete__option' : 'autocomplete__option autocomplete__option--odd')
-                    li.innerHTML = `${value.name}, ${value.id}, ${value.postcode}, ${value.la}`;
-                    li.addEventListener('click', function () {
-                        selectSchool(value.name, value.id, value.la, value.postcode, index);
-                    });
-                    document.getElementById(`schoolList${index}`).appendChild(li);
-                    counter++;
+                const list = document.getElementById(`schoolList${index}`);
+                list.innerHTML = '';
+                resultCache[index] = data;
+                activeIndex[index] = -1;
+
+                data.forEach((school, i) => {
+                    const li = document.createElement('li');
+                    li.id = `school-${index}-${i}`;
+                    li.setAttribute('role', 'option');
+                    li.setAttribute('aria-selected', 'false');
+                    li.className = 'autocomplete__option';
+                    li.textContent =
+                        `${school.name}, ${school.id}, ${school.postcode}, ${school.la}`;
+
+                    li.addEventListener('click', () =>
+                        selectSchool(school, index));
+
+                    list.appendChild(li);
                 });
-            })
-            .catch(error => {
-                console.error('Error searching schools:', error);
-                document.getElementById(`schoolList${index}`).innerHTML = '<li class="autocomplete__option">Error searching schools</li>';
+
+                openList(index);
             });
-    } else {
-        document.getElementById(`schoolList${index}`).innerHTML = '';
     }
-}
 
-function selectSchool(school, urn, la, postcode, index) {
-    // element_ids
-    var schoolName = `ChildList[${index}].School.Name`;
-    var schoolURN = `ChildList[${index}].School.URN`;
-    var schoolPostcode = `ChildList[${index}].School.Postcode`;
-    var schoolLA = `ChildList[${index}].School.LA`;
-    var schoolSearch = `ChildList[${index}].School`
-    // set values
-    document.getElementById(schoolName).value = school;
-    document.getElementById(schoolURN).value = urn;
-    document.getElementById(schoolPostcode).value = postcode;
-    document.getElementById(schoolLA).value = la;
-    document.getElementById(schoolSearch).value = `${school}, ${urn}, ${postcode}, ${la}`;
-    // set in local storage
-    localStorage.setItem(`schoolName${index}`, school);
-    localStorage.setItem(`schoolURN${index}`, urn);
-    localStorage.setItem(`schoolPostcode${index}`, postcode);
-    localStorage.setItem(`schoolLA${index}`, la);
-    // clear options
-    document.getElementById(`schoolList${index}`).innerHTML = '';
-}
+    function selectSchool(school, index) {
+        document.getElementById(`ChildList[${index}].School`).value =
+            `${school.name}, ${school.id}, ${school.postcode}, ${school.la}`;
 
-// Set up event listeners for all school search inputs
-let schoolSearch = document.getElementsByClassName("school-search");
-for (let i = 0; i < schoolSearch.length; i++) {
-    schoolSearch[i].oninput = function () {
-        searchSchool(this.value, i)
+        document.getElementById(`ChildList[${index}].School.Name`).value = school.name;
+        document.getElementById(`ChildList[${index}].School.URN`).value = school.id;
+        document.getElementById(`ChildList[${index}].School.Postcode`).value = school.postcode;
+        document.getElementById(`ChildList[${index}].School.LA`).value = school.la;
+
+        closeList(index);
     }
-}
+
+    function handleKeyDown(e, index) {
+        const list = document.getElementById(`schoolList${index}`);
+        if (list.hidden) return;
+
+        const options = list.querySelectorAll('[role="option"]');
+
+        switch (e.key) {
+            case 'ArrowDown':
+                e.preventDefault();
+                setActive(index,
+                    activeIndex[index] < options.length - 1
+                        ? activeIndex[index] + 1 : 0);
+                break;
+
+            case 'ArrowUp':
+                e.preventDefault();
+                setActive(index,
+                    activeIndex[index] > 0
+                        ? activeIndex[index] - 1 : options.length - 1);
+                break;
+
+            case 'Enter':
+                if (activeIndex[index] >= 0) {
+                    e.preventDefault();
+                    selectSchool(resultCache[index][activeIndex[index]], index);
+                }
+                break;
+
+            case 'Escape':
+                closeList(index);
+                break;
+        }
+    }
+
+    document.querySelectorAll('.school-search').forEach((input, index) => {
+        input.addEventListener('input', e => searchSchool(e.target.value, index));
+        input.addEventListener('keydown', e => handleKeyDown(e, index));
+    });
+
+});


### PR DESCRIPTION
- Remove incorrect aria-label and link input to label by ID. Make school results accessible using only keyboard.
- Remove redundant 'init' commands to avoid console errors.
- Make school results accsessible using only keyboard on enter_child_details.
- Disambiguate 'Change' link for screenreaders.
- Missed adding an indexer.

https://dfedigital.atlassian.net/browse/ELIG-3050

