### PR TITLE
ELIG-3032: Add X-Robots-Tag support to disable search indexing

### DIFF
--- a/CheckYourEligibility.FrontEnd/Program.cs
+++ b/CheckYourEligibility.FrontEnd/Program.cs
@@ -133,7 +133,11 @@ app.Use((context, next) =>
     context.Response.Headers["Cache-Control"] = "Private";
     context.Response.Headers["X-XSS-Protection"] = "1; mode=block";
     context.Response.Headers["X-Content-Type-Options"] = "nosniff";
-    return next.Invoke();
+	if (!builder.Configuration.GetValue<bool>("AllowSearchIndexing"))
+	{
+		context.Response.Headers["X-Robots-Tag"] = "none";
+	}
+	return next.Invoke();
 });
 app.UseHttpsRedirection();
 app.UseSession();

--- a/CheckYourEligibility.FrontEnd/appsettings.json
+++ b/CheckYourEligibility.FrontEnd/appsettings.json
@@ -15,6 +15,7 @@
     }
   },
   "AllowedHosts": "*",
+  "AllowSearchIndexing": false,
   "MaxChildren": 99,
   "Api": {
     "Host": "",


### PR DESCRIPTION
Added X-Robots-Tag to response headers when app setting "AllowSearchIndexing" = "false"