### PR TITLE
ELIG-3092 fsm parent portal survey goes to the wrong place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,3 +410,6 @@ FodyWeavers.xsd
 
 # Cypress
 /tests/cypress/downloads/
+
+#Copilot
+/.github/copilot-instructions.md

--- a/CheckYourEligibility.FrontEnd/Views/Check/Application_Sent.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Check/Application_Sent.cshtml
@@ -82,7 +82,7 @@
     <p>Each school will contact you with a decision when your evidence has been reviewed.</p>
     <p>This usually takes about 1 week, but if you do not receive an update contact your school administrator.</p>
 
-    <p><a href="https://dferesearch.fra1.qualtrics.com/jfe/form/SV_bjB0MQiSJtvhyZw">What did you think about this service?</a> (takes 30 seconds)</p>
+    <p><a href="https://dferesearch.fra1.qualtrics.com/jfe/form/SV_a3JNJGKsdKLCDYi" target="_blank">What did you think about this service?</a> (takes 30 seconds)</p>
 
     <a href="../" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
         Finish and leave service

--- a/CheckYourEligibility.FrontEnd/Views/Shared/_Layout.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Shared/_Layout.cshtml
@@ -67,7 +67,7 @@
                     beta
                 </strong>
                 <span class="govuk-phase-banner__text">
-                    This is a new service - your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
+                    This is a new service - your <a class="govuk-link" href="https://dferesearch.fra1.qualtrics.com/jfe/form/SV_a3JNJGKsdKLCDYi" target="_blank">feedback</a> will help us to improve it.
                 </span>
             </p>
         </div>

--- a/CheckYourEligibility.FrontEnd/Views/Shared/_Layout_StartNow.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Shared/_Layout_StartNow.cshtml
@@ -67,10 +67,10 @@
     <div class="govuk-phase-banner app-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
             <strong class="govuk-tag govuk-phase-banner__content__tag">
-                alpha
+                beta
             </strong>
             <span class="govuk-phase-banner__text">
-                    This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
+                    This is a new service – your <a class="govuk-link" href="https://dferesearch.fra1.qualtrics.com/jfe/form/SV_a3JNJGKsdKLCDYi" target="_blank">feedback</a> will help us to improve it.
                 </span>
         </p>
     </div>


### PR DESCRIPTION
- Change alpha banner to beta banner.
- Update the survey URL for banners and application_sent.cshtml.

https://dfedigital.atlassian.net/browse/ELIG-3092