### PR TITLE
ELIG-3097 PARENT review all date time strings output in html to ensure they are using the correct format and daylight savings adjustments

### DIFF
--- a/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
@@ -4,21 +4,21 @@ using FluentAssertions;
 
 namespace CheckYourEligibility.Admin.Tests.Models
 {
+    [SetUpFixture]
+    public class GlobalTestSetup
+    {
+        public static TimeZoneInfo UkTimeZone;
+
+        [OneTimeSetUp]
+        public void Init()
+        {
+            UkTimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+        }
+    }
+
     [TestFixture]
     public class DateTimeExtensionsTests
     {
-        [SetUpFixture]
-        public class GlobalTestSetup
-        {
-            public static TimeZoneInfo UkTimeZone;
-
-            [OneTimeSetUp]
-            public void Init()
-            {
-                UkTimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
-            }
-        }
-
         [Test]
         public void GetLocalTime_With_UTC_Date_In_Winter_Should_Return_GMT_Time()
         {

--- a/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
@@ -66,7 +66,7 @@ namespace CheckYourEligibility.Admin.Tests.Models
         {
             // Arrange
             // 15 June 2026 11:00 BST = 10:00 UTC
-            var localDate = new DateTime(2026, 6, 15, 11, 0, 0, DateTimeKind.Unspecified); 
+            var localDate = new DateTime(2026, 6, 15, 11, 0, 0); 
 
             // Act
             var result = DateTimeExtensions.GetUTCTime(localDate); 

--- a/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
@@ -75,7 +75,7 @@ namespace CheckYourEligibility.Admin.Tests.Models
             var result = utcDate.ToLocalString12HourFormatReadableWithAt();
 
             // Assert
-            result.Should().Be("05 Feb 2026 2:05pm");
+            result.Should().Be("05 Feb 2026 at 2:05pm");
         }
 
         [Test]
@@ -88,14 +88,14 @@ namespace CheckYourEligibility.Admin.Tests.Models
             var result = utcDate.ToLocalString12HourFormatReadableWithAt();
 
             // Assert
-            result.Should().Be("05 Jul 2026 3:05pm");
+            result.Should().Be("05 Jul 2026 at 3:05pm");
         }
 
         [Test]
         public void GetDateTimeOffsetFromString_In_Winter_Should_Have_Zero_Offset()
         {
             // Arrange
-            var input = "2026-01-20 9:00";
+            var input = "2026-01-20 09:00";
 
             // Act
             var result = DateTimeExtensions.GetDateTimeOffsetFromString(input);
@@ -108,7 +108,7 @@ namespace CheckYourEligibility.Admin.Tests.Models
         public void GetDateTimeOffsetFromString_In_Summer_Should_Have_One_Hour_Offset()
         {
             // Arrange
-            var input = "2026-06-20 9:00";
+            var input = "2026-06-20 09:00";
 
             // Act
             var result = DateTimeExtensions.GetDateTimeOffsetFromString(input);

--- a/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
@@ -72,10 +72,10 @@ namespace CheckYourEligibility.Admin.Tests.Models
             var utcDate = new DateTime(2026, 2, 5, 14, 5, 0, DateTimeKind.Utc);
 
             // Act
-            var result = utcDate.ToLocalString12HourFormatReadable();
+            var result = utcDate.ToLocalString12HourFormatReadableWithAt();
 
             // Assert
-            result.Should().Be("05 Feb 2026 02:05pm");
+            result.Should().Be("05 Feb 2026 2:05pm");
         }
 
         [Test]
@@ -85,17 +85,17 @@ namespace CheckYourEligibility.Admin.Tests.Models
             var utcDate = new DateTime(2026, 7, 5, 14, 5, 0, DateTimeKind.Utc);
 
             // Act
-            var result = utcDate.ToLocalString12HourFormatReadable();
+            var result = utcDate.ToLocalString12HourFormatReadableWithAt();
 
             // Assert
-            result.Should().Be("05 Jul 2026 03:05pm");
+            result.Should().Be("05 Jul 2026 3:05pm");
         }
 
         [Test]
         public void GetDateTimeOffsetFromString_In_Winter_Should_Have_Zero_Offset()
         {
             // Arrange
-            var input = "2026-01-20 09:00";
+            var input = "2026-01-20 9:00";
 
             // Act
             var result = DateTimeExtensions.GetDateTimeOffsetFromString(input);
@@ -108,7 +108,7 @@ namespace CheckYourEligibility.Admin.Tests.Models
         public void GetDateTimeOffsetFromString_In_Summer_Should_Have_One_Hour_Offset()
         {
             // Arrange
-            var input = "2026-06-20 09:00";
+            var input = "2026-06-20 9:00";
 
             // Act
             var result = DateTimeExtensions.GetDateTimeOffsetFromString(input);

--- a/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
@@ -7,6 +7,17 @@ namespace CheckYourEligibility.Admin.Tests.Models
     [TestFixture]
     public class DateTimeExtensionsTests
     {
+        [SetUpFixture]
+        public class GlobalTestSetup
+        {
+            public static TimeZoneInfo UkTimeZone;
+
+            [OneTimeSetUp]
+            public void Init()
+            {
+                UkTimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+            }
+        }
 
         [Test]
         public void GetLocalTime_With_UTC_Date_In_Winter_Should_Return_GMT_Time()

--- a/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
@@ -1,0 +1,121 @@
+﻿using CheckYourEligibility.FrontEnd.Models;
+using FluentAssertions;
+
+
+namespace CheckYourEligibility.Admin.Tests.Models
+{ 
+    [TestFixture]
+    public class DateTimeExtensionsTests
+    {
+
+        [Test]
+        public void GetLocalTime_With_UTC_Date_In_Winter_Should_Return_GMT_Time()
+        {
+            // Arrange
+            var utcDate = new DateTime(2026, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+
+            // Act
+            var result = DateTimeExtensions.GetLocalTime(utcDate);
+
+            // Assert
+            result.Hour.Should().Be(10);
+            result.Minute.Should().Be(30);
+        }
+
+        [Test]
+        public void GetLocalTime_With_UTC_Date_In_Summer_Should_Return_BST_Time()
+        {
+            // Arrange
+            var utcDate = new DateTime(2026, 6, 15, 10, 30, 0, DateTimeKind.Utc);
+
+            // Act
+            var result = DateTimeExtensions.GetLocalTime(utcDate);
+
+            // Assert
+            result.Hour.Should().Be(11);
+            result.Minute.Should().Be(30);
+        }
+
+        [Test]
+        public void GetUTCTime_With_Utc_Date_Should_Return_Same_Date()
+        {
+            // Arrange
+            var utcDate = new DateTime(2026, 2, 10, 14, 0, 0, DateTimeKind.Utc);
+
+            // Act
+            var result = DateTimeExtensions.GetUTCTime(utcDate);
+
+            // Assert
+            result.Should().Be(utcDate);
+            result.Kind.Should().Be(DateTimeKind.Utc);
+        }
+
+        [Test]
+        public void GetUTCTime_With_Local_BST_Date_Should_Convert_To_Utc()
+        {
+            // Arrange
+            // 15 June 2026 11:00 BST = 10:00 UTC
+            var localDate = new DateTime(2026, 6, 15, 11, 0, 0, DateTimeKind.Unspecified);
+
+            // Act
+            var result = DateTimeExtensions.GetUTCTime(localDate);
+
+            // Assert
+            result.Hour.Should().Be(10);
+            result.Kind.Should().Be(DateTimeKind.Utc);
+        }
+
+        [Test]
+        public void ToLocalString12HourFormatReadable_Should_Format_GMT_Date_Correctly()
+        {
+            // Arrange
+            var utcDate = new DateTime(2026, 2, 5, 14, 5, 0, DateTimeKind.Utc);
+
+            // Act
+            var result = utcDate.ToLocalString12HourFormatReadable();
+
+            // Assert
+            result.Should().Be("05 Feb 2026 02:05pm");
+        }
+
+        [Test]
+        public void ToLocalString12HourFormatReadable_Should_Format_BST_Date_Correctly()
+        {
+            // Arrange
+            var utcDate = new DateTime(2026, 7, 5, 14, 5, 0, DateTimeKind.Utc);
+
+            // Act
+            var result = utcDate.ToLocalString12HourFormatReadable();
+
+            // Assert
+            result.Should().Be("05 Jul 2026 03:05pm");
+        }
+
+        [Test]
+        public void GetDateTimeOffsetFromString_In_Winter_Should_Have_Zero_Offset()
+        {
+            // Arrange
+            var input = "2026-01-20 09:00";
+
+            // Act
+            var result = DateTimeExtensions.GetDateTimeOffsetFromString(input);
+
+            // Assert
+            result.Offset.Should().Be(TimeSpan.Zero);
+        }
+
+        [Test]
+        public void GetDateTimeOffsetFromString_In_Summer_Should_Have_One_Hour_Offset()
+        {
+            // Arrange
+            var input = "2026-06-20 09:00";
+
+            // Act
+            var result = DateTimeExtensions.GetDateTimeOffsetFromString(input);
+
+            // Assert
+            result.Offset.Should().Be(TimeSpan.FromHours(1));
+        }
+    }
+
+}

--- a/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
@@ -3,7 +3,7 @@ using FluentAssertions;
 
 
 namespace CheckYourEligibility.Admin.Tests.Models
-{ 
+{
     [TestFixture]
     public class DateTimeExtensionsTests
     {
@@ -55,14 +55,14 @@ namespace CheckYourEligibility.Admin.Tests.Models
         {
             // Arrange
             // 15 June 2026 11:00 BST = 10:00 UTC
-            var localDate = new DateTime(2026, 6, 15, 11, 0, 0, DateTimeKind.Unspecified);
+            var localDate = new DateTime(2026, 6, 15, 11, 0, 0, DateTimeKind.Unspecified); 
 
             // Act
-            var result = DateTimeExtensions.GetUTCTime(localDate);
+            var result = DateTimeExtensions.GetUTCTime(localDate); 
 
             // Assert
-            result.Hour.Should().Be(10);
-            result.Kind.Should().Be(DateTimeKind.Utc);
+            result.Hour.Should().Be(10); 
+            result.Kind.Should().Be(DateTimeKind.Utc); 
         }
 
         [Test]

--- a/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
@@ -4,18 +4,6 @@ using FluentAssertions;
 
 namespace CheckYourEligibility.Admin.Tests.Models
 {
-    [SetUpFixture]
-    public class GlobalTestSetup
-    {
-        public static TimeZoneInfo UkTimeZone;
-
-        [OneTimeSetUp]
-        public void Init()
-        {
-            UkTimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
-        }
-    }
-
     [TestFixture]
     public class DateTimeExtensionsTests
     {
@@ -45,35 +33,6 @@ namespace CheckYourEligibility.Admin.Tests.Models
             // Assert
             result.Hour.Should().Be(11);
             result.Minute.Should().Be(30);
-        }
-
-        [Test]
-        public void GetUTCTime_With_Utc_Date_Should_Return_Same_Date()
-        {
-            // Arrange
-            var utcDate = new DateTime(2026, 2, 10, 14, 0, 0, DateTimeKind.Utc);
-
-            // Act
-            var result = DateTimeExtensions.GetUTCTime(utcDate);
-
-            // Assert
-            result.Should().Be(utcDate);
-            result.Kind.Should().Be(DateTimeKind.Utc);
-        }
-
-        [Test]
-        public void GetUTCTime_With_Local_BST_Date_Should_Convert_To_Utc()
-        {
-            // Arrange
-            // 15 June 2026 11:00 BST = 10:00 UTC
-            var localDate = new DateTime(2026, 6, 15, 11, 0, 0); 
-
-            // Act
-            var result = DateTimeExtensions.GetUTCTime(localDate); 
-
-            // Assert
-            result.Hour.Should().Be(10); 
-            result.Kind.Should().Be(DateTimeKind.Utc); 
         }
 
         [Test]

--- a/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿using CheckYourEligibility.FrontEnd.Models;
 using FluentAssertions;
 
-namespace CheckYourEligibility.Admin.Tests.Models
+namespace CheckYourEligibility.FrontEnd.Tests.Models
 {
     [TestFixture]
     public class DateTimeExtensionsTests

--- a/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Models/ExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿using CheckYourEligibility.FrontEnd.Models;
 using FluentAssertions;
 
-
 namespace CheckYourEligibility.Admin.Tests.Models
 {
     [TestFixture]
@@ -60,32 +59,5 @@ namespace CheckYourEligibility.Admin.Tests.Models
             // Assert
             result.Should().Be("05 Jul 2026 at 3:05pm");
         }
-
-        [Test]
-        public void GetDateTimeOffsetFromString_In_Winter_Should_Have_Zero_Offset()
-        {
-            // Arrange
-            var input = "2026-01-20 09:00";
-
-            // Act
-            var result = DateTimeExtensions.GetDateTimeOffsetFromString(input);
-
-            // Assert
-            result.Offset.Should().Be(TimeSpan.Zero);
-        }
-
-        [Test]
-        public void GetDateTimeOffsetFromString_In_Summer_Should_Have_One_Hour_Offset()
-        {
-            // Arrange
-            var input = "2026-06-20 09:00";
-
-            // Act
-            var result = DateTimeExtensions.GetDateTimeOffsetFromString(input);
-
-            // Assert
-            result.Offset.Should().Be(TimeSpan.FromHours(1));
-        }
     }
-
 }

--- a/CheckYourEligibility.FrontEnd/CheckYourEligibility.FrontEnd.csproj
+++ b/CheckYourEligibility.FrontEnd/CheckYourEligibility.FrontEnd.csproj
@@ -1,43 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <RootNamespace>CheckYourEligibility.FrontEnd</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>CheckYourEligibility.FrontEnd</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <Content Include="Attributes\NinoAttribute.cs" />
-        <Content Include="Attributes\NameAttribute.cs" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.12.0" />
-        <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
-        <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
-        <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
-        <PackageReference Include="FluentValidation" Version="11.11.0" />
-        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.1" />
-        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.1" />
-        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.1" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
-        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-
-        <PackageReference Include="GovUk.OneLogin.AspNetCore" Version="0.3.1" />
-        <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Content Update="Views\Check\Upload_Guidance_Digital.cshtml">
-        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      </Content>
-    </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="GovUk.OneLogin.AspNetCore" Version="0.3.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+  
 </Project>

--- a/CheckYourEligibility.FrontEnd/Models/Extensions.cs
+++ b/CheckYourEligibility.FrontEnd/Models/Extensions.cs
@@ -1,0 +1,40 @@
+﻿using System.Globalization;
+
+namespace CheckYourEligibility.FrontEnd.Models;
+
+public static class DateTimeExtensions
+{
+    public static TimeZoneInfo TimeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(timezone);
+
+    private const string timezone = "GMT Standard Time";
+
+    public static DateTimeOffset GetDateTimeOffsetFromString(string datetime)
+    {
+        DateTime raw = DateTime.ParseExact(datetime, "yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None);
+
+        DateTimeOffset offset = new DateTimeOffset(raw, TimeZoneInfo.BaseUtcOffset);
+        var rules = TimeZoneInfo.GetAdjustmentRules();
+        if (TimeZoneInfo.IsDaylightSavingTime(raw))
+        {
+            offset = new DateTimeOffset(raw.AddHours(-1), rules.First().DaylightDelta);
+        }
+        return offset;
+    }
+    public static DateTime GetLocalTime(DateTime time)
+    {
+        return TimeZoneInfo.ConvertTimeFromUtc(time, TimeZoneInfo);
+    }
+
+    public static DateTime GetUTCTime(DateTime time)
+    {
+        if (time.Kind != DateTimeKind.Utc)
+        {
+            time = TimeZoneInfo.ConvertTimeToUtc(time);
+        }
+        return time;
+    }
+    public static string ToLocalString12HourFormatReadableWithAt(this DateTime datetime)
+    {
+        return GetLocalTime(datetime).ToString("dd MMM yyyy 'at' h:mmtt").Replace("AM", "am").Replace("PM", "pm");
+    }
+}

--- a/CheckYourEligibility.FrontEnd/Models/Extensions.cs
+++ b/CheckYourEligibility.FrontEnd/Models/Extensions.cs
@@ -26,12 +26,6 @@ public static class DateTimeExtensions
         return TimeZoneInfo.ConvertTimeFromUtc(time, TimeZoneInfo);
     }
 
-    public static DateTime GetUTCTime(DateTime time)
-    {
-        time = TimeZoneInfo.ConvertTimeToUtc(time);
-        return time;
-    }
-
     public static string ToLocalString12HourFormatReadableWithAt(this DateTime datetime)
     {
         return GetLocalTime(datetime).ToString("dd MMM yyyy 'at' h:mmtt").Replace("AM", "am").Replace("PM", "pm");

--- a/CheckYourEligibility.FrontEnd/Models/Extensions.cs
+++ b/CheckYourEligibility.FrontEnd/Models/Extensions.cs
@@ -20,6 +20,7 @@ public static class DateTimeExtensions
         }
         return offset;
     }
+
     public static DateTime GetLocalTime(DateTime time)
     {
         return TimeZoneInfo.ConvertTimeFromUtc(time, TimeZoneInfo);
@@ -27,13 +28,10 @@ public static class DateTimeExtensions
 
     public static DateTime GetUTCTime(DateTime time)
     {
-        //if (time.Kind != DateTimeKind.Utc)
-        //{
-        //Always get as UTC
-            time = TimeZoneInfo.ConvertTimeToUtc(time);
-        //}
+        time = TimeZoneInfo.ConvertTimeToUtc(time);
         return time;
     }
+
     public static string ToLocalString12HourFormatReadableWithAt(this DateTime datetime)
     {
         return GetLocalTime(datetime).ToString("dd MMM yyyy 'at' h:mmtt").Replace("AM", "am").Replace("PM", "pm");

--- a/CheckYourEligibility.FrontEnd/Models/Extensions.cs
+++ b/CheckYourEligibility.FrontEnd/Models/Extensions.cs
@@ -27,10 +27,11 @@ public static class DateTimeExtensions
 
     public static DateTime GetUTCTime(DateTime time)
     {
-        if (time.Kind != DateTimeKind.Utc)
-        {
+        //if (time.Kind != DateTimeKind.Utc)
+        //{
+        //Always get as UTC
             time = TimeZoneInfo.ConvertTimeToUtc(time);
-        }
+        //}
         return time;
     }
     public static string ToLocalString12HourFormatReadableWithAt(this DateTime datetime)

--- a/CheckYourEligibility.FrontEnd/Models/Extensions.cs
+++ b/CheckYourEligibility.FrontEnd/Models/Extensions.cs
@@ -1,25 +1,10 @@
-﻿using System.Globalization;
-
-namespace CheckYourEligibility.FrontEnd.Models;
+﻿namespace CheckYourEligibility.FrontEnd.Models;
 
 public static class DateTimeExtensions
 {
     public static TimeZoneInfo TimeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(timezone);
 
     private const string timezone = "GMT Standard Time";
-
-    public static DateTimeOffset GetDateTimeOffsetFromString(string datetime)
-    {
-        DateTime raw = DateTime.ParseExact(datetime, "yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None);
-
-        DateTimeOffset offset = new DateTimeOffset(raw, TimeZoneInfo.BaseUtcOffset);
-        var rules = TimeZoneInfo.GetAdjustmentRules();
-        if (TimeZoneInfo.IsDaylightSavingTime(raw))
-        {
-            offset = new DateTimeOffset(raw.AddHours(-1), rules.First().DaylightDelta);
-        }
-        return offset;
-    }
 
     public static DateTime GetLocalTime(DateTime time)
     {

--- a/CheckYourEligibility.FrontEnd/Views/Check/Application_Sent.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Check/Application_Sent.cshtml
@@ -16,12 +16,7 @@
             <div class="govuk-panel govuk-panel--confirmation">
                 <h1 class="govuk-panel__title">@ViewData["Title"]</h1>
                 <div class="govuk-panel__body">
-                    @{
-                        var createdDate = responses[0].Data.Created;
-                        var ukTimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
-                        var ukTime = TimeZoneInfo.ConvertTime(createdDate, ukTimeZone);
-                    }
-                    Submitted on<br><strong>@ukTime.ToString("dd MMM yyyy 'at' h:mm tt")</strong>
+                    Submitted on<br><strong>@responses[0].Data.Created.ToLocalString12HourFormatReadableWithAt()</strong>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Add Extensions and tests for time display and update Application_Sent to use it. 
- Amend ExtensionsTests in line with removal of leading 0's on time.
NOTE-Extension modified to include 'at' between date and time for Parent Portal only.

https://dfedigital.atlassian.net/browse/ELIG-3097