### PR TITLE
ELIG-3368-PARENT-FRONT-END-Implement-design-changes-to-show-correlation-ID-and-error-code-to-user-for-single-check-technical-error-outcomes

### DIFF
--- a/CheckYourEligibility.FrontEnd.Tests/Controllers/CheckControllerTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Controllers/CheckControllerTests.cs
@@ -704,27 +704,25 @@ public class CheckControllerTests
         _getCheckStatusUseCaseMock.Verify(x => x.Execute(responseJson, _sessionMock.Object), Times.Once);
     }
 
-    [TestCase("unknownStatus", "Outcome/Technical_Error")]
-    public async Task Given_Loader_When_Status_TechnicalError_Should_ReturnErrorCode(string status, string expectedView)
+    public async Task Given_Loader_When_Status_TechnicalError_Should_ReturnErrorCode()
     {
         // Arrange
         var response = new CheckEligibilityResponse
         {
-            Data = new StatusValue { Status = status }
+            Data = new StatusValue { Status = "error", ErrorCode = "TE21" }
         };
         var responseJson = JsonConvert.SerializeObject(response);
         _sut.TempData["Response"] = responseJson;
 
-        var expectedResponse = new StatusValue() { Status = status, ErrorCode = "TE21" };
         _getCheckStatusUseCaseMock
             .Setup(x => x.Execute(responseJson, _sessionMock.Object))
-            .ReturnsAsync(expectedResponse);
+            .ReturnsAsync(response.Data);
         // Act
         var result = await _sut.Loader();
 
         // Assert
         var viewResult = result as ViewResult;
-        viewResult.ViewData["ErrorCode"].Should().Be("TE21");
+        viewResult.ViewData["ErrorCode"].Should().Be(response.Data.ErrorCode);
     }
 
     [Test]

--- a/CheckYourEligibility.FrontEnd.Tests/Controllers/CheckControllerTests.cs
+++ b/CheckYourEligibility.FrontEnd.Tests/Controllers/CheckControllerTests.cs
@@ -295,7 +295,7 @@ public class CheckControllerTests
                 {
                     Id = 10002,
                     LocalAuthority = new ApplicationResponse.ApplicationEstablishment.EstablishmentLocalAuthority
-                        { Id = 123 }
+                    { Id = 123 }
                 },
                 Reference = ""
             },
@@ -616,9 +616,10 @@ public class CheckControllerTests
         var responseJson = JsonConvert.SerializeObject(response);
         _sut.TempData["Response"] = responseJson;
 
+        var expectedResponse = new StatusValue() { Status = "queuedForProcessing" };
         _getCheckStatusUseCaseMock
             .Setup(x => x.Execute(responseJson, _sessionMock.Object))
-            .ReturnsAsync("queuedForProcessing");
+            .ReturnsAsync(expectedResponse);
 
         // Act
         var result = await _sut.Loader();
@@ -689,10 +690,10 @@ public class CheckControllerTests
         var responseJson = JsonConvert.SerializeObject(response);
         _sut.TempData["Response"] = responseJson;
 
+        var expectedResponse = new StatusValue() { Status = status };
         _getCheckStatusUseCaseMock
             .Setup(x => x.Execute(responseJson, _sessionMock.Object))
-            .ReturnsAsync(status);
-
+            .ReturnsAsync(expectedResponse);
         // Act
         var result = await _sut.Loader();
 
@@ -703,6 +704,28 @@ public class CheckControllerTests
         _getCheckStatusUseCaseMock.Verify(x => x.Execute(responseJson, _sessionMock.Object), Times.Once);
     }
 
+    [TestCase("unknownStatus", "Outcome/Technical_Error")]
+    public async Task Given_Loader_When_Status_TechnicalError_Should_ReturnErrorCode(string status, string expectedView)
+    {
+        // Arrange
+        var response = new CheckEligibilityResponse
+        {
+            Data = new StatusValue { Status = status }
+        };
+        var responseJson = JsonConvert.SerializeObject(response);
+        _sut.TempData["Response"] = responseJson;
+
+        var expectedResponse = new StatusValue() { Status = status, ErrorCode = "TE21" };
+        _getCheckStatusUseCaseMock
+            .Setup(x => x.Execute(responseJson, _sessionMock.Object))
+            .ReturnsAsync(expectedResponse);
+        // Act
+        var result = await _sut.Loader();
+
+        // Assert
+        var viewResult = result as ViewResult;
+        viewResult.ViewData["ErrorCode"].Should().Be("TE21");
+    }
 
     [Test]
     public async Task Given_CheckAnswers_When_LoadingPage_Should_LoadCheckAnswersPage()
@@ -770,7 +793,7 @@ public class CheckControllerTests
     //    // Setup application response - ensure it has email and reference
     //    _applicationSaveItemResponse.Data.ParentEmail = email;
     //    _applicationSaveItemResponse.Data.Reference = "TEST001";
-        
+
     //    var applicationResponses = new List<ApplicationSaveItemResponse> { _applicationSaveItemResponse };
     //    _submitApplicationUseCaseMock
     //        .Setup(x => x.Execute(_fsmApplication, checkResult, userId, email))
@@ -843,7 +866,7 @@ public class CheckControllerTests
 
     //    // Verify notification was attempted
     //    _sendNotificationUseCaseMock.Verify(x => x.Execute(It.IsAny<NotificationRequest>()), Times.Once);
-        
+
     //    // Verify the process continued despite notification failure
     //    _sut.TempData.Should().ContainKey("FsmApplicationResponses");
     //}
@@ -952,7 +975,7 @@ public class CheckControllerTests
         var email = "test@example.com";
         var checkResult = CheckEligibilityStatus.eligible.ToString();
         var reference = "FSM123456";
-        
+
         NotificationRequest capturedRequest = null;
 
         // Setup session with TryGetValue instead of extension method
@@ -976,7 +999,7 @@ public class CheckControllerTests
         _applicationSaveItemResponse.Data.Reference = reference;
 
         var applicationResponses = new List<ApplicationSaveItemResponse> { _applicationSaveItemResponse };
-        
+
         _submitApplicationUseCaseMock
             .Setup(x => x.Execute(_fsmApplication, checkResult, userId, email))
             .ReturnsAsync(applicationResponses);
@@ -1649,7 +1672,7 @@ public class CheckControllerTests
     public async Task UploadEvidence_Post_When_Existing_Evidence_In_TempData_Should_Preserve_It()
     {
         // Arrange
-        var request = new FsmApplication(); 
+        var request = new FsmApplication();
         request.EvidenceFiles = new List<IFormFile>();
 
         // Create existing evidence in TempData

--- a/CheckYourEligibility.FrontEnd/Boundary/Responses/CheckEligibilityStatusResponse.cs
+++ b/CheckYourEligibility.FrontEnd/Boundary/Responses/CheckEligibilityStatusResponse.cs
@@ -8,4 +8,9 @@ public class CheckEligibilityStatusResponse
 public class StatusValue
 {
     public string Status { get; set; }
+
+    public string ErrorCode { get; set; }
+
+    public string CorrelationID { get; set; }
+
 }

--- a/CheckYourEligibility.FrontEnd/Controllers/CheckController.cs
+++ b/CheckYourEligibility.FrontEnd/Controllers/CheckController.cs
@@ -174,13 +174,13 @@ public class CheckController : Controller
         {
             var outcome = await _getCheckStatusUseCase.Execute(responseJson, HttpContext.Session);
 
-            if (outcome == "queuedForProcessing")
+            if (outcome.Status == "queuedForProcessing")
                 // Save the response back to TempData for the next poll
                 TempData["Response"] = responseJson;
 
-            _logger.LogError(outcome);
+            _logger.LogError(outcome.Status);
 
-            switch (outcome)
+            switch (outcome.Status)
             {
                 case "eligible":
                     return View("Outcome/Eligible");
@@ -199,6 +199,8 @@ public class CheckController : Controller
                     break;
 
                 default:
+                    ViewData["CorellationID"] = outcome.CorrelationID;
+                    ViewData["ErrorCode"] = outcome.ErrorCode;
                     return View("Outcome/Technical_Error");
             }
         }

--- a/CheckYourEligibility.FrontEnd/Usecases/GetCheckStatusUseCase.cs
+++ b/CheckYourEligibility.FrontEnd/Usecases/GetCheckStatusUseCase.cs
@@ -6,7 +6,7 @@ namespace CheckYourEligibility.FrontEnd.UseCases;
 
 public interface IGetCheckStatusUseCase
 {
-    Task<string> Execute(string responseJson, ISession session);
+    Task<StatusValue> Execute(string responseJson, ISession session);
 }
 
 public class GetCheckStatusUseCase : IGetCheckStatusUseCase
@@ -22,7 +22,7 @@ public class GetCheckStatusUseCase : IGetCheckStatusUseCase
         _checkGateway = checkGateway ?? throw new ArgumentNullException(nameof(checkGateway));
     }
 
-    public async Task<string> Execute(string responseJson, ISession session)
+    public async Task<StatusValue> Execute(string responseJson, ISession session)
     {
         if (string.IsNullOrEmpty(responseJson))
         {
@@ -40,9 +40,14 @@ public class GetCheckStatusUseCase : IGetCheckStatusUseCase
             throw new Exception("Null response received from GetStatus.");
         }
 
+        if (response.Links.Get_EligibilityCheck != null)
+        {
+            check.Data.CorrelationID = response.Links.Get_EligibilityCheck.Replace("/check/", "");
+        }
+
         _logger.LogInformation($"Received status: {check.Data.Status}");
         session.SetString("CheckResult", check.Data.Status);
 
-        return check.Data.Status;
+        return check.Data;
     }
 }

--- a/CheckYourEligibility.FrontEnd/Views/Check/Outcome/Technical_Error.cshtml
+++ b/CheckYourEligibility.FrontEnd/Views/Check/Outcome/Technical_Error.cshtml
@@ -1,8 +1,8 @@
 @{
     ViewData["Title"] = "Check failed";
+    string correlationID = ViewData["CorellationID"]?.ToString();
+    string errorCode = ViewData["ErrorCode"]?.ToString();
 }
-
-@model string
 
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link-nolink"></a>
@@ -12,17 +12,29 @@
             <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
                  data-module="govuk-notification-banner">
                 <div class="govuk-notification-banner__header">
-                    <h2 class="govuk-notification-banner__title"
-                        id="govuk-notification-banner-title">@ViewData["Title"]</h2>
+                    <h1 class="govuk-notification-banner__title"
+                        id="govuk-notification-banner-title">
+                        @ViewData["Title"]
+                    </h1>
                 </div>
                 <div class="govuk-notification-banner__content">
                     <p class="govuk-notification-banner__heading">There’s been a technical error.</p>
-                    <p><a href="~/Check/Enter_Details">Try again</a>, ensuring you’ve entered your details accurately.
+                    <p>
+                        <a href="~/Check/Enter_Details">Try again</a>, ensuring you’ve entered your details accurately.
                     </p>
                 </div>
             </div>
 
-            <h1 class="govuk-heading-l">If the check keeps failing</h1>
+            <h2>How to report this error</h2>
+            <p>Copy the following details and send them to our team using the <a target="_blank" href="https://customerhelpportal.education.gov.uk/">Customer Help Portal</a>.</p>
+            @if (correlationID != null)
+            {
+                <p>Correlation ID: @correlationID</p>
+            }
+            <p>Error code: @errorCode</p>
+            <p>Please copy and paste the details rather than sending a screenshot.</p>
+
+            <h2 class="govuk-heading-l">If the check keeps failing</h2>
             <p>Contact your school administrator.</p>
         </div>
     </div>

--- a/tests/cypress/e2e/EligibilityCheck/TechnicalError.spec.Redacted.ts
+++ b/tests/cypress/e2e/EligibilityCheck/TechnicalError.spec.Redacted.ts
@@ -1,0 +1,45 @@
+//Test set as Redacted due to the length of time a tech error response takes to return, so we do not want to
+//  include this in regular test runs. The timeout is set to how long it will keep checking rather than a 
+// fixed wait, but our intention is to see if we can generate the response faster before including
+// this test more permanently.
+
+import { GOV_UK_ONE_LOGIN_SITE, GOV_UK_ONE_LOGIN_URL } from "../../support/constants";
+
+let schoolApprovedForPrivateBeta = "Kilmorie Primary School, 100718, SE23 2SP, Lewisham";
+let schoolApprovedForPrivateBetaSearchString = "Kilmorie Primary";
+
+describe('TechnicalError outcome should display Error Code and CorrelationID', () => {
+
+    let lastName = Cypress.env('lastName');
+
+    it('TechnicalError outcome should display Error Code', () => {
+        cy.visit('/');
+        cy.get('h1').should('include.text', 'Check if your children can get free school meals');
+        cy.contains('Start now').click()
+
+        cy.get('[id="SelectedSchoolURN"]').type(schoolApprovedForPrivateBetaSearchString);
+        cy.get('#schoolListResults', {timeout: 5000})
+            .contains(schoolApprovedForPrivateBeta)
+            .click({ force: true})
+        cy.contains('Continue').click();
+
+        cy.url().should('include', '/Home/SchoolInPrivateBeta');
+        cy.get('h1').should('include.text', 'You can use this test service');
+        cy.contains('Check your eligibility').click();
+
+        cy.url().should('include', '/Check/Enter_Details');
+        cy.get('h1').should('include.text', 'Enter your details');
+        cy.get('#FirstName').should('be.visible').type('Tim');
+        cy.get('#LastName').should('be.visible').type('TESTER');
+        cy.get('#DateOfBirth\\.Day').should('be.visible').type('01');
+        cy.get('#DateOfBirth\\.Month').should('be.visible').type('01');
+        cy.get('#DateOfBirth\\.Year').should('be.visible').type('1980');
+        cy.get('input[type="radio"][value="true"]').click();
+        cy.get('#IsNinoSelected').click();
+        cy.get('#NationalInsuranceNumber').type('XX123456C')
+        cy.contains('Save and continue').click();
+        cy.get('h1',{ timeout: 120000 }).should('include.text', 'Check failed');
+        cy.get('body').should('include.text', 'Error code: STE50');
+        cy.get('body').should('include.text', 'Correlation ID:'); //Only shown if Guid was available from the check
+    });
+});

--- a/tests/cypress/e2e/EligibilityCheck/TechnicalError.spec.SKIP.ts
+++ b/tests/cypress/e2e/EligibilityCheck/TechnicalError.spec.SKIP.ts
@@ -1,7 +1,7 @@
-//Test set as Redacted due to the length of time a tech error response takes to return, so we do not want to
+//Test set as SKIP due to the length of time a tech error response takes to return, so we do not want to
 //  include this in regular test runs. The timeout is set to how long it will keep checking rather than a 
 // fixed wait, but our intention is to see if we can generate the response faster before including
-// this test more permanently.
+// this test more permanently. Then just remove SKIP from filename to re-enable it.
 
 import { GOV_UK_ONE_LOGIN_SITE, GOV_UK_ONE_LOGIN_URL } from "../../support/constants";
 


### PR DESCRIPTION
- Add Error Code and Correlation ID to the Technical_Error outcome for single checks.

https://dfedigital.atlassian.net/browse/ELIG-3368